### PR TITLE
fix: add Next.js build cache to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,13 @@ jobs:
 
       - run: npm ci
 
+      - uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-
+
       - name: Lint
         run: npm run lint
 


### PR DESCRIPTION
## Summary
- Cache `.next/cache` between CI runs using `actions/cache@v4`
- Keyed on `package-lock.json` + source file hashes for correct invalidation
- Eliminates the "No build cache found" warning and speeds up subsequent builds

## Test plan
- [ ] CI passes with cache step
- [ ] Second run on same branch hits cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)