### PR TITLE
fix: add dashboard link on landing page for authenticated users

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,7 +19,7 @@ export default function Home() {
 
         <div className="w-full pt-4 [&>div]:flex-col [&>div]:w-full [&_a]:w-full [&_a]:justify-center">
           <Suspense>
-            <AuthButton />
+            <AuthButton showDashboardLink />
           </Suspense>
         </div>
       </div>

--- a/components/auth-button.tsx
+++ b/components/auth-button.tsx
@@ -3,7 +3,11 @@ import { Button } from "./ui/button";
 import { createClient } from "@/lib/supabase/server";
 import { LogoutButton } from "./logout-button";
 
-export async function AuthButton() {
+export async function AuthButton({
+  showDashboardLink = false,
+}: {
+  showDashboardLink?: boolean;
+} = {}) {
   const supabase = await createClient();
 
   // You can also use getUser() which will be slower.
@@ -14,9 +18,11 @@ export async function AuthButton() {
   return user ? (
     <div className="flex items-center gap-2 sm:gap-4">
       <span className="hidden sm:inline text-sm">Hey, {user.email}!</span>
-      <Button asChild size="sm" variant={"default"}>
-        <Link href="/protected">Dashboard</Link>
-      </Button>
+      {showDashboardLink && (
+        <Button asChild size="sm" variant={"default"}>
+          <Link href="/protected">Dashboard</Link>
+        </Button>
+      )}
       <LogoutButton />
     </div>
   ) : (

--- a/components/auth-button.tsx
+++ b/components/auth-button.tsx
@@ -14,6 +14,9 @@ export async function AuthButton() {
   return user ? (
     <div className="flex items-center gap-2 sm:gap-4">
       <span className="hidden sm:inline text-sm">Hey, {user.email}!</span>
+      <Button asChild size="sm" variant={"default"}>
+        <Link href="/protected">Dashboard</Link>
+      </Button>
       <LogoutButton />
     </div>
   ) : (


### PR DESCRIPTION
## Summary
- Adds a "Dashboard" button to the landing page when a user is logged in
- Previously, authenticated users only saw their email and a logout button with no way to navigate to the dashboard

## Test plan
- [ ] Visit root URL while logged in — verify "Dashboard" button appears
- [ ] Click "Dashboard" — verify it navigates to `/protected`
- [ ] Visit root URL while logged out — verify sign in/sign up buttons still show (no dashboard button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)