### PR TITLE
fix: remove space in verification code email

### DIFF
--- a/__tests__/lib/email.test.ts
+++ b/__tests__/lib/email.test.ts
@@ -39,7 +39,7 @@ describe("sendVerificationEmail", () => {
     expect(call.text).toContain(
       "https://fluitplanner.nl/poll/abc123?verify=token123",
     );
-    expect(call.html).toContain("384 721"); // formatted with space
+    expect(call.html).toContain("384721");
     expect(call.html).toContain(
       "https://fluitplanner.nl/poll/abc123?verify=token123",
     );

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -31,8 +31,6 @@ export async function sendVerificationEmail({
 }: VerificationEmailParams): Promise<void> {
   const from =
     process.env.SMTP_FROM || "Fluitplanner <noreply@fluitplanner.nl>";
-  const formattedCode = `${code.slice(0, 3)} ${code.slice(3)}`;
-
   const maxRetries = 2;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
@@ -42,7 +40,7 @@ export async function sendVerificationEmail({
         to,
         subject: "Your Fluitplanner verification code",
         text: `Your verification code is: ${code}\n\nOr click this link to verify: ${magicLink}\n\nThis code expires in 30 minutes.`,
-        html: verificationEmailHtml({ formattedCode, magicLink }),
+        html: verificationEmailHtml({ code, magicLink }),
       });
       return;
     } catch (err) {
@@ -81,10 +79,10 @@ function escapeHtml(str: string): string {
 }
 
 function verificationEmailHtml({
-  formattedCode,
+  code,
   magicLink,
 }: {
-  formattedCode: string;
+  code: string;
   magicLink: string;
 }): string {
   const safeLink = escapeHtml(magicLink);
@@ -107,7 +105,7 @@ function verificationEmailHtml({
         <tr>
           <td style="padding:32px;">
             <p style="margin:0 0 8px;font-size:15px;color:#4a5e53;">Your verification code is:</p>
-            <p style="margin:0 0 24px;font-size:36px;font-weight:700;letter-spacing:6px;color:#1a2e24;font-family:'Courier New',monospace;">${formattedCode}</p>
+            <p style="margin:0 0 24px;font-size:36px;font-weight:700;letter-spacing:10px;color:#1a2e24;font-family:'Courier New',monospace;">${code}</p>
             <p style="margin:0 0 16px;font-size:15px;color:#4a5e53;">Or click the button below:</p>
             <a href="${safeLink}" style="display:inline-block;padding:12px 28px;background-color:#1B9A6C;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;border-radius:8px;">Verify my email</a>
             <p style="margin:24px 0 0;font-size:13px;color:#6b7f73;">This code expires in 30 minutes.</p>


### PR DESCRIPTION
## Summary
- Removes the space in the middle of the 6-digit verification code in emails (e.g. `384 721` → `384721`), which caused users to accidentally paste only 5 digits, leaving the Verify button disabled
- Increases `letter-spacing` from 6px to 10px in the email HTML for visual readability without interfering with copy-paste

## Test plan
- [x] Unit tests updated and passing
- [ ] Send a verification email and confirm the code displays without spaces
- [ ] Copy-paste the code from the email into the verification input and confirm all 6 digits are captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)