### PR TITLE
chore: auto-merge release-please PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,5 +14,13 @@ jobs:
 
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           release-type: node
+
+      - name: Auto-merge release PR
+        if: steps.release.outputs.pr
+        run: gh pr merge --auto --squash "$PR_NUMBER"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}


### PR DESCRIPTION
## Summary
- Enable GitHub auto-merge (squash) on release-please PRs so they merge automatically once CI passes

## Test plan
- [ ] Verify auto-merge is enabled in repo settings (Settings > General > Allow auto-merge)
- [ ] Push a conventional commit to `main` and confirm the release PR gets auto-merge enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)