### PR TITLE
fix: add --repo flag to gh pr merge in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Auto-merge release PR
         if: steps.release.outputs.pr
-        run: gh pr merge --auto --squash "$PR_NUMBER"
+        run: gh pr merge --auto --squash "$PR_NUMBER" --repo "${{ github.repository }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}


### PR DESCRIPTION
## Summary
- The auto-merge step in the Release workflow failed with `fatal: not a git repository` because there's no checkout step — `gh` CLI couldn't resolve the repo context
- Fixed by adding `--repo` flag to `gh pr merge` so it doesn't need a local `.git` directory

## Test plan
- [ ] Merge this PR and verify the Release workflow succeeds (auto-merge is enabled on PR #34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)