### PR TITLE
feat: add dashboard link on poll page for planners

### DIFF
--- a/components/poll-response/poll-response-page.tsx
+++ b/components/poll-response/poll-response-page.tsx
@@ -7,6 +7,8 @@ import { UmpireIdentifier } from "@/components/poll-response/umpire-identifier";
 import { VerificationForm } from "@/components/poll-response/verification-form";
 import { findUmpireById, getMyResponses } from "@/lib/actions/public-polls";
 import { verifyMagicLink } from "@/lib/actions/verification";
+import { LayoutDashboard } from "lucide-react";
+import Link from "next/link";
 import type {
   AvailabilityResponse,
   Poll,
@@ -203,9 +205,19 @@ export function PollResponsePage({
             Responding as <strong>{umpire.name}</strong>
           </p>
         </div>
-        <Button variant="ghost" size="sm" onClick={handleSwitchUser}>
-          Not you?
-        </Button>
+        <div className="flex items-center gap-1">
+          {umpire.auth_user_id && (
+            <Button variant="ghost" size="sm" asChild>
+              <Link href="/protected">
+                <LayoutDashboard className="mr-1 h-4 w-4" />
+                Dashboard
+              </Link>
+            </Button>
+          )}
+          <Button variant="ghost" size="sm" onClick={handleSwitchUser}>
+            Not you?
+          </Button>
+        </div>
       </div>
       <AvailabilityForm
         pollId={poll.id}


### PR DESCRIPTION
## Summary
- Show a "Dashboard" button on the public poll response page when the umpire has a linked planner account (`auth_user_id` is set)
- Hidden for regular umpires who don't have a planner account
- Uses existing `umpire.auth_user_id` field — no new API calls needed

## Test plan
- [ ] Open a poll as an umpire with `auth_user_id` set → "Dashboard" button visible
- [ ] Open a poll as a regular umpire (`auth_user_id` is null) → no "Dashboard" button
- [ ] Click "Dashboard" button → navigates to `/protected`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Dashboard quick-access link for authenticated users, enabling direct navigation to the dashboard from the poll response page.

* **Improvements**
  * Reorganized user authentication controls to improve navigation flow and usability while preserving the ability to switch users between responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->