### PR TITLE
fix: check auth session for poll dashboard button

### DIFF
--- a/components/__tests__/poll-response-page-integration.test.tsx
+++ b/components/__tests__/poll-response-page-integration.test.tsx
@@ -15,6 +15,14 @@ vi.mock("@/lib/actions/verification", () => ({
   requestVerification: vi.fn(),
 }));
 
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+    },
+  }),
+}));
+
 import { findUmpireById, getMyResponses } from "@/lib/actions/public-polls";
 
 const mockFindUmpireById = vi.mocked(findUmpireById);

--- a/components/poll-response/poll-response-page.tsx
+++ b/components/poll-response/poll-response-page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { AvailabilityForm } from "@/components/poll-response/availability-form";
 import { UmpireIdentifier } from "@/components/poll-response/umpire-identifier";
 import { VerificationForm } from "@/components/poll-response/verification-form";
+import { createClient } from "@/lib/supabase/client";
 import { findUmpireById, getMyResponses } from "@/lib/actions/public-polls";
 import { verifyMagicLink } from "@/lib/actions/verification";
 import { LayoutDashboard } from "lucide-react";
@@ -59,6 +60,7 @@ export function PollResponsePage({
 }: Props) {
   const [loading, setLoading] = useState(true);
   const [umpire, setUmpire] = useState<Umpire | null>(null);
+  const [isPlanner, setIsPlanner] = useState(false);
   const [existingResponses, setExistingResponses] = useState<
     AvailabilityResponse[]
   >([]);
@@ -69,6 +71,13 @@ export function PollResponsePage({
 
   useEffect(() => {
     async function init() {
+      // Check if user has an active planner session
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (user) setIsPlanner(true);
+
       // Try magic link verification first
       if (verifyToken) {
         const result = await verifyMagicLink(verifyToken);
@@ -206,7 +215,7 @@ export function PollResponsePage({
           </p>
         </div>
         <div className="flex items-center gap-1">
-          {umpire.auth_user_id && (
+          {isPlanner && (
             <Button variant="ghost" size="sm" asChild>
               <Link href="/protected">
                 <LayoutDashboard className="mr-1 h-4 w-4" />


### PR DESCRIPTION
## Summary
- The dashboard button on the poll page was never showing because `umpire.auth_user_id` is never written to the umpires table
- Now checks for an active Supabase auth session in the browser instead, correctly detecting planners
- Verified with Playwright: button shows for authenticated planners, hidden for regular umpires

## Test plan
- [x] Log in as planner, open poll page → "Dashboard" button visible
- [x] Open poll page in fresh browser (no auth) → no "Dashboard" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session detection to more reliably identify active planner sessions during app initialization.
  * Dashboard link now displays correctly based on verified planner session status.
  * Enhanced user identification process for planner access with better initial load handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->