### PR TITLE
Add availability guard enforcement and dashboard warning

### DIFF
--- a/__tests__/lib/actions/dashboard.test.ts
+++ b/__tests__/lib/actions/dashboard.test.ts
@@ -326,6 +326,8 @@ describe("getRecentActivity", () => {
       ],
       error: null,
     });
+    // 4. warning events
+    mockLimit.mockResolvedValueOnce({ data: [], error: null });
 
     const { getRecentActivity } = await import("@/lib/actions/dashboard");
     const events = await getRecentActivity();
@@ -362,6 +364,7 @@ describe("getRecentActivity", () => {
     mockLimit.mockResolvedValueOnce({ data: responses, error: null });
     mockLimit.mockResolvedValueOnce({ data: [], error: null });
     mockLimit.mockResolvedValueOnce({ data: [], error: null });
+    mockLimit.mockResolvedValueOnce({ data: [], error: null });
 
     const { getRecentActivity } = await import("@/lib/actions/dashboard");
     const events = await getRecentActivity();
@@ -386,6 +389,7 @@ describe("getRecentActivity", () => {
     mockLimit.mockResolvedValueOnce({ data: [], error: null });
     mockLimit.mockResolvedValueOnce({ data: [], error: null });
     mockLimit.mockResolvedValueOnce({ data: matches, error: null });
+    mockLimit.mockResolvedValueOnce({ data: [], error: null });
 
     const { getRecentActivity } = await import("@/lib/actions/dashboard");
     const events = await getRecentActivity();
@@ -406,6 +410,7 @@ describe("getRecentActivity", () => {
     }));
     mockLimit.mockResolvedValueOnce({ data: [], error: null });
     mockLimit.mockResolvedValueOnce({ data: assignments, error: null });
+    mockLimit.mockResolvedValueOnce({ data: [], error: null });
     mockLimit.mockResolvedValueOnce({ data: [], error: null });
 
     const { getRecentActivity } = await import("@/lib/actions/dashboard");
@@ -441,6 +446,7 @@ describe("getRecentActivity", () => {
       created_at: `2026-02-03T${String(i).padStart(2, "0")}:00:00Z`,
     }));
     mockLimit.mockResolvedValueOnce({ data: matches, error: null });
+    mockLimit.mockResolvedValueOnce({ data: [], error: null });
 
     const { getRecentActivity } = await import("@/lib/actions/dashboard");
     const events = await getRecentActivity();
@@ -448,5 +454,32 @@ describe("getRecentActivity", () => {
     expect(events).toHaveLength(10);
     // First event should be the most recent (matches from Feb 3)
     expect(events[0].type).toBe("match_added");
+  });
+
+  it("includes availability warning events", async () => {
+    mockLimit.mockResolvedValueOnce({ data: [], error: null });
+    mockLimit.mockResolvedValueOnce({ data: [], error: null });
+    mockLimit.mockResolvedValueOnce({ data: [], error: null });
+    mockLimit.mockResolvedValueOnce({
+      data: [
+        {
+          created_at: "2026-02-13T08:00:00Z",
+          outcome: "blocked",
+          umpires: { name: "Jan" },
+          polls: { title: "Weekend Poll" },
+        },
+      ],
+      error: null,
+    });
+
+    const { getRecentActivity } = await import("@/lib/actions/dashboard");
+    const events = await getRecentActivity();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "availability_warning",
+      umpire: "Jan",
+      pollTitle: "Weekend Poll",
+      outcome: "blocked",
+    });
   });
 });

--- a/__tests__/lib/actions/public-polls.test.ts
+++ b/__tests__/lib/actions/public-polls.test.ts
@@ -301,7 +301,18 @@ describe("submitResponses", () => {
       status: "partial_saved",
       blockedSlots: ["slot-1"],
     });
-    expect(mockUpsert).toHaveBeenCalled();
+    expect(mockUpsert).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          poll_id: "poll-1",
+          slot_id: "slot-2",
+          participant_name: "Jan",
+          response: "yes",
+          umpire_id: "ump-1",
+        }),
+      ],
+      { onConflict: "poll_id,slot_id,umpire_id" },
+    );
   });
 
   it("deletes response when null is submitted", async () => {

--- a/__tests__/lib/actions/public-polls.test.ts
+++ b/__tests__/lib/actions/public-polls.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 /* ------------------------------------------------------------------ */
-/*  Supabase mock                                                      */
+/*  Supabase mocks                                                     */
 /* ------------------------------------------------------------------ */
 
 const mockSelect = vi.fn();
@@ -10,6 +10,8 @@ const mockSingle = vi.fn();
 const mockOrder = vi.fn();
 const mockInsert = vi.fn();
 const mockUpsert = vi.fn();
+const mockIn = vi.fn();
+const mockDelete = vi.fn();
 
 function chainable() {
   return {
@@ -19,10 +21,30 @@ function chainable() {
     order: mockOrder,
     insert: mockInsert,
     upsert: mockUpsert,
+    in: mockIn,
+    delete: mockDelete,
   };
 }
 
 const mockFrom = vi.fn(() => chainable());
+
+const svcSelect = vi.fn();
+const svcEq = vi.fn();
+const svcMaybeSingle = vi.fn();
+const svcIn = vi.fn();
+const svcInsert = vi.fn();
+
+function serviceChainable() {
+  return {
+    select: svcSelect,
+    eq: svcEq,
+    maybeSingle: svcMaybeSingle,
+    in: svcIn,
+    insert: svcInsert,
+  };
+}
+
+const mockServiceFrom = vi.fn(() => serviceChainable());
 
 vi.mock("@/lib/tenant", () => ({
   requireTenantId: vi.fn(async () => "test-org-id"),
@@ -37,9 +59,11 @@ vi.mock("@/lib/supabase/server", () => ({
   })),
 }));
 
-/* ------------------------------------------------------------------ */
-/*  Helpers                                                            */
-/* ------------------------------------------------------------------ */
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: vi.fn(() => ({
+    from: mockServiceFrom,
+  })),
+}));
 
 function resetChain() {
   for (const fn of [
@@ -50,30 +74,43 @@ function resetChain() {
     mockOrder,
     mockInsert,
     mockUpsert,
+    mockIn,
+    mockDelete,
+    mockServiceFrom,
+    svcSelect,
+    svcEq,
+    svcMaybeSingle,
+    svcIn,
+    svcInsert,
   ]) {
     fn.mockReset();
   }
-  // Default: every chained call returns chainable()
+
   mockFrom.mockReturnValue(chainable());
   mockSelect.mockReturnValue(chainable());
   mockEq.mockReturnValue(chainable());
   mockOrder.mockReturnValue(chainable());
   mockInsert.mockReturnValue(chainable());
   mockUpsert.mockReturnValue(chainable());
+  mockIn.mockReturnValue(chainable());
+  mockDelete.mockReturnValue(chainable());
+
+  mockServiceFrom.mockReturnValue(serviceChainable());
+  svcSelect.mockReturnValue(serviceChainable());
+  svcEq.mockReturnValue(serviceChainable());
+  svcIn.mockReturnValue(serviceChainable());
+  svcInsert.mockReturnValue(serviceChainable());
+
   mockSingle.mockResolvedValue({ data: null, error: null });
+  svcMaybeSingle.mockResolvedValue({ data: null, error: null });
 }
 
 beforeEach(() => {
   resetChain();
 });
 
-/* ================================================================== */
-/*  getPollByToken                                                     */
-/* ================================================================== */
-
 describe("getPollByToken", () => {
   it("returns null for a non-existent token", async () => {
-    // .from("polls").select("*").eq("token", token).single() → error
     mockSingle.mockResolvedValueOnce({
       data: null,
       error: { message: "not found" },
@@ -85,290 +122,217 @@ describe("getPollByToken", () => {
   });
 
   it("returns poll and slots for a valid token", async () => {
-    const poll = {
-      id: "poll-1",
-      title: "Week 10",
-      token: "abc123",
-      status: "open",
-      created_by: "user-1",
-      created_at: "2026-02-01T00:00:00Z",
-    };
-
-    const slots = [
-      {
-        id: "slot-1",
-        poll_id: "poll-1",
-        start_time: "2026-02-15T10:00:00Z",
-        end_time: "2026-02-15T12:00:00Z",
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        id: "poll-1",
+        title: "Week 10",
+        token: "abc123",
+        status: "open",
+        created_by: "user-1",
+        created_at: "2026-02-01T00:00:00Z",
+        organization_id: "org-1",
       },
-    ];
+      error: null,
+    });
 
-    // First call: .from("polls")...single() → poll
-    mockSingle.mockResolvedValueOnce({ data: poll, error: null });
-
-    // Second call: .from("poll_slots")...order() → slots
-    // order returns { data, error } directly for the second query
-    mockOrder.mockResolvedValueOnce({ data: slots, error: null });
+    mockOrder.mockResolvedValueOnce({
+      data: [
+        {
+          id: "slot-1",
+          poll_id: "poll-1",
+          start_time: "2026-02-15T10:00:00Z",
+          end_time: "2026-02-15T12:00:00Z",
+        },
+      ],
+      error: null,
+    });
 
     const { getPollByToken } = await import("@/lib/actions/public-polls");
     const result = await getPollByToken("abc123");
 
-    expect(result).not.toBeNull();
-    expect(result!.poll.id).toBe("poll-1");
-    expect(result!.slots).toHaveLength(1);
-    expect(result!.slots[0].id).toBe("slot-1");
+    expect(result?.poll.id).toBe("poll-1");
+    expect(result?.slots).toHaveLength(1);
   });
 });
-
-/* ================================================================== */
-/*  findOrCreateUmpire                                                 */
-/* ================================================================== */
-
-describe("findOrCreateUmpire", () => {
-  it("returns existing umpire when email matches", async () => {
-    const umpire = {
-      id: "ump-1",
-      auth_user_id: null,
-      name: "Jan",
-      email: "jan@example.com",
-      level: 1,
-      created_at: "2026-01-01T00:00:00Z",
-      updated_at: "2026-01-01T00:00:00Z",
-    };
-
-    // .from("umpires").select("*").eq("email", ...).single() → umpire
-    mockSingle.mockResolvedValueOnce({ data: umpire, error: null });
-
-    const { findOrCreateUmpire } = await import("@/lib/actions/public-polls");
-    const result = await findOrCreateUmpire("Jan@Example.com");
-    expect(result).toEqual(umpire);
-  });
-
-  it("returns null when email not found and no name provided", async () => {
-    mockSingle.mockResolvedValueOnce({
-      data: null,
-      error: { message: "not found", code: "PGRST116" },
-    });
-
-    const { findOrCreateUmpire } = await import("@/lib/actions/public-polls");
-    const result = await findOrCreateUmpire("unknown@example.com");
-    expect(result).toBeNull();
-  });
-
-  it("creates new umpire when email not found and name provided", async () => {
-    const newUmpire = {
-      id: "ump-new",
-      auth_user_id: null,
-      name: "Piet",
-      email: "piet@example.com",
-      level: 1,
-      created_at: "2026-01-01T00:00:00Z",
-      updated_at: "2026-01-01T00:00:00Z",
-    };
-
-    // First: lookup fails
-    mockSingle.mockResolvedValueOnce({
-      data: null,
-      error: { message: "not found", code: "PGRST116" },
-    });
-    // Second: insert → select → single → new umpire
-    mockSingle.mockResolvedValueOnce({ data: newUmpire, error: null });
-
-    const { findOrCreateUmpire } = await import("@/lib/actions/public-polls");
-    const result = await findOrCreateUmpire("Piet@Example.com", "Piet");
-    expect(result).toEqual(newUmpire);
-  });
-
-  it("links umpire to organization when pollId is provided", async () => {
-    const umpire = {
-      id: "ump-1",
-      auth_user_id: null,
-      name: "Jan",
-      email: "jan@example.com",
-      level: 1,
-      created_at: "2026-01-01T00:00:00Z",
-      updated_at: "2026-01-01T00:00:00Z",
-    };
-
-    // First call: lookup umpire → found
-    mockSingle.mockResolvedValueOnce({ data: umpire, error: null });
-    // Second call: linkUmpireToOrg → polls lookup returns org id
-    mockSingle.mockResolvedValueOnce({
-      data: { organization_id: "org-123" },
-      error: null,
-    });
-    // Third call: upsert to organization_umpires
-    mockUpsert.mockResolvedValueOnce({ error: null });
-
-    const { findOrCreateUmpire } = await import("@/lib/actions/public-polls");
-    const result = await findOrCreateUmpire(
-      "jan@example.com",
-      undefined,
-      "poll-1",
-    );
-    expect(result).toEqual(umpire);
-
-    // Verify polls lookup and org_umpires upsert were called
-    expect(mockFrom).toHaveBeenCalledWith("polls");
-    expect(mockFrom).toHaveBeenCalledWith("organization_umpires");
-  });
-
-  it("skips org linking when poll has no organization_id", async () => {
-    const umpire = {
-      id: "ump-1",
-      auth_user_id: null,
-      name: "Jan",
-      email: "jan@example.com",
-      level: 1,
-      created_at: "2026-01-01T00:00:00Z",
-      updated_at: "2026-01-01T00:00:00Z",
-    };
-
-    // Lookup umpire → found
-    mockSingle.mockResolvedValueOnce({ data: umpire, error: null });
-    // linkUmpireToOrg → polls lookup returns null org
-    mockSingle.mockResolvedValueOnce({
-      data: { organization_id: null },
-      error: null,
-    });
-
-    const { findOrCreateUmpire } = await import("@/lib/actions/public-polls");
-    const result = await findOrCreateUmpire(
-      "jan@example.com",
-      undefined,
-      "poll-1",
-    );
-    expect(result).toEqual(umpire);
-
-    // org_umpires upsert should NOT have been called
-    expect(mockFrom).not.toHaveBeenCalledWith("organization_umpires");
-  });
-});
-
-/* ================================================================== */
-/*  findUmpireById                                                     */
-/* ================================================================== */
-
-describe("findUmpireById", () => {
-  it("returns umpire when found", async () => {
-    const umpire = {
-      id: "ump-1",
-      auth_user_id: null,
-      name: "Jan",
-      email: "jan@example.com",
-      level: 1,
-      created_at: "2026-01-01T00:00:00Z",
-      updated_at: "2026-01-01T00:00:00Z",
-    };
-
-    mockSingle.mockResolvedValueOnce({ data: umpire, error: null });
-
-    const { findUmpireById } = await import("@/lib/actions/public-polls");
-    const result = await findUmpireById("ump-1");
-    expect(result).toEqual(umpire);
-  });
-
-  it("returns null when not found", async () => {
-    mockSingle.mockResolvedValueOnce({
-      data: null,
-      error: { message: "not found" },
-    });
-
-    const { findUmpireById } = await import("@/lib/actions/public-polls");
-    const result = await findUmpireById("bad-id");
-    expect(result).toBeNull();
-  });
-});
-
-/* ================================================================== */
-/*  getMyResponses                                                     */
-/* ================================================================== */
-
-describe("getMyResponses", () => {
-  it("returns responses for a given poll and umpire", async () => {
-    const responses = [
-      {
-        id: "resp-1",
-        poll_id: "poll-1",
-        slot_id: "slot-1",
-        participant_name: "Jan",
-        response: "yes",
-        umpire_id: "ump-1",
-        created_at: "2026-02-01T00:00:00Z",
-        updated_at: "2026-02-01T00:00:00Z",
-      },
-    ];
-
-    // .from("availability_responses").select("*").eq("poll_id", ...).eq("umpire_id", ...) → responses
-    // First eq returns chainable (default), second eq resolves with data
-    mockEq.mockReturnValueOnce(chainable());
-    mockEq.mockResolvedValueOnce({ data: responses, error: null });
-
-    const { getMyResponses } = await import("@/lib/actions/public-polls");
-    const result = await getMyResponses("poll-1", "ump-1");
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe("resp-1");
-  });
-});
-
-/* ================================================================== */
-/*  submitResponses                                                    */
-/* ================================================================== */
 
 describe("submitResponses", () => {
-  it("throws when poll is closed", async () => {
-    // .from("polls").select("status").eq("id", ...).single() → closed poll
+  it("returns confirm_required in warn mode before confirmed submit", async () => {
     mockSingle.mockResolvedValueOnce({
-      data: { status: "closed" },
+      data: { status: "open", organization_id: "org-1" },
       error: null,
     });
 
-    const { submitResponses } = await import("@/lib/actions/public-polls");
-    await expect(
-      submitResponses("poll-1", "ump-1", "Jan", [
-        { slotId: "slot-1", response: "yes" },
-      ]),
-    ).rejects.toThrow("Poll is closed");
-  });
-
-  it("throws when poll is not found", async () => {
-    mockSingle.mockResolvedValueOnce({
-      data: null,
-      error: { message: "not found" },
-    });
-
-    const { submitResponses } = await import("@/lib/actions/public-polls");
-    await expect(
-      submitResponses("bad-poll", "ump-1", "Jan", [
-        { slotId: "slot-1", response: "yes" },
-      ]),
-    ).rejects.toThrow("Poll not found");
-  });
-
-  it("returns early when responses array is empty", async () => {
-    const { submitResponses } = await import("@/lib/actions/public-polls");
-    // Should not throw and should not call supabase
-    await submitResponses("poll-1", "ump-1", "Jan", []);
-    expect(mockFrom).not.toHaveBeenCalled();
-  });
-
-  it("upserts responses for an open poll", async () => {
-    // .from("polls").select("status").eq("id", ...).single() → open poll
-    mockSingle.mockResolvedValueOnce({
-      data: { status: "open" },
+    mockIn.mockResolvedValueOnce({
+      data: [{ slot_id: "slot-1", response: "yes" }],
       error: null,
     });
 
-    // upsert call → success
-    mockUpsert.mockResolvedValueOnce({ error: null });
+    svcMaybeSingle.mockResolvedValueOnce({
+      data: { availability_guard_policy: "warn" },
+      error: null,
+    });
+
+    svcEq.mockReturnValueOnce(serviceChainable());
+    svcEq.mockReturnValueOnce(serviceChainable());
+    svcEq.mockResolvedValueOnce({
+      data: [{ match_id: "m1" }],
+      error: null,
+    });
+
+    svcIn.mockResolvedValueOnce({
+      data: [
+        {
+          id: "m1",
+          date: "2026-02-15",
+          start_time: "2026-02-15T10:10:00Z",
+          home_team: "A",
+          away_team: "B",
+          competition: null,
+          venue: null,
+          field: null,
+          required_level: 1,
+          created_by: "u1",
+          created_at: "2026-01-01T00:00:00Z",
+          organization_id: "org-1",
+        },
+      ],
+      error: null,
+    });
+
+    svcEq.mockResolvedValueOnce({
+      data: [
+        {
+          id: "slot-1",
+          poll_id: "poll-1",
+          start_time: "2026-02-15T10:00:00Z",
+          end_time: "2026-02-15T12:00:00Z",
+        },
+      ],
+      error: null,
+    });
+
+    svcInsert.mockResolvedValueOnce({ error: null });
 
     const { submitResponses } = await import("@/lib/actions/public-polls");
-    await submitResponses("poll-1", "ump-1", "Jan", [
-      { slotId: "slot-1", response: "yes" },
-      { slotId: "slot-2", response: "no" },
+    const result = await submitResponses("poll-1", "ump-1", "Jan", [
+      { slotId: "slot-1", response: "no" },
     ]);
 
-    // Verify upsert was called
+    expect(result).toEqual({
+      status: "confirm_required",
+      affectedSlots: ["slot-1"],
+    });
+  });
+
+  it("saves allowed changes and returns partial_saved in block mode", async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: { status: "open", organization_id: "org-1" },
+      error: null,
+    });
+
+    mockIn.mockResolvedValueOnce({
+      data: [
+        { slot_id: "slot-1", response: "yes" },
+        { slot_id: "slot-2", response: "if_need_be" },
+      ],
+      error: null,
+    });
+
+    svcMaybeSingle.mockResolvedValueOnce({
+      data: { availability_guard_policy: "block" },
+      error: null,
+    });
+
+    svcEq.mockReturnValueOnce(serviceChainable());
+    svcEq.mockReturnValueOnce(serviceChainable());
+    svcEq.mockResolvedValueOnce({
+      data: [{ match_id: "m1" }],
+      error: null,
+    });
+
+    svcIn.mockResolvedValueOnce({
+      data: [
+        {
+          id: "m1",
+          date: "2026-02-15",
+          start_time: "2026-02-15T10:10:00Z",
+          home_team: "A",
+          away_team: "B",
+          competition: null,
+          venue: null,
+          field: null,
+          required_level: 1,
+          created_by: "u1",
+          created_at: "2026-01-01T00:00:00Z",
+          organization_id: "org-1",
+        },
+      ],
+      error: null,
+    });
+
+    svcEq.mockResolvedValueOnce({
+      data: [
+        {
+          id: "slot-1",
+          poll_id: "poll-1",
+          start_time: "2026-02-15T10:00:00Z",
+          end_time: "2026-02-15T12:00:00Z",
+        },
+        {
+          id: "slot-2",
+          poll_id: "poll-1",
+          start_time: "2026-02-15T12:00:00Z",
+          end_time: "2026-02-15T14:00:00Z",
+        },
+      ],
+      error: null,
+    });
+
+    mockUpsert.mockResolvedValueOnce({ error: null });
+    svcInsert.mockResolvedValueOnce({ error: null });
+
+    const { submitResponses } = await import("@/lib/actions/public-polls");
+    const result = await submitResponses("poll-1", "ump-1", "Jan", [
+      { slotId: "slot-1", response: "no" },
+      { slotId: "slot-2", response: "yes" },
+    ]);
+
+    expect(result).toEqual({
+      status: "partial_saved",
+      blockedSlots: ["slot-1"],
+    });
     expect(mockUpsert).toHaveBeenCalled();
+  });
+
+  it("deletes response when null is submitted", async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: { status: "open", organization_id: "org-1" },
+      error: null,
+    });
+
+    mockIn.mockResolvedValueOnce({
+      data: [{ slot_id: "slot-1", response: "yes" }],
+      error: null,
+    });
+
+    svcMaybeSingle.mockResolvedValueOnce({
+      data: { availability_guard_policy: "warn" },
+      error: null,
+    });
+
+    svcEq.mockReturnValueOnce(serviceChainable());
+    svcEq.mockReturnValueOnce(serviceChainable());
+    svcEq.mockResolvedValueOnce({ data: [], error: null });
+
+    mockDelete.mockReturnValue(chainable());
+    mockIn.mockResolvedValueOnce({ error: null });
+
+    const { submitResponses } = await import("@/lib/actions/public-polls");
+    const result = await submitResponses("poll-1", "ump-1", "Jan", [
+      { slotId: "slot-1", response: null },
+    ]);
+
+    expect(result).toEqual({ status: "saved" });
+    expect(mockDelete).toHaveBeenCalled();
   });
 });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { Geist } from "next/font/google";
 import { ThemeProvider } from "next-themes";
 import { Toaster } from "@/components/ui/sonner";
 import { NextIntlClientProvider } from "next-intl";
@@ -17,12 +16,6 @@ export const metadata: Metadata = {
   description: "Field hockey umpire availability and match assignment",
 };
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  display: "swap",
-  subsets: ["latin"],
-});
-
 export default async function RootLayout({
   children,
 }: Readonly<{
@@ -33,7 +26,7 @@ export default async function RootLayout({
 
   return (
     <html lang={locale} suppressHydrationWarning>
-      <body className={`${geistSans.className} antialiased`}>
+      <body className="antialiased">
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/app/protected/settings/page.tsx
+++ b/app/protected/settings/page.tsx
@@ -2,11 +2,43 @@ import { Suspense } from "react";
 import { TableSkeleton } from "@/components/skeletons";
 import { getManagedTeams } from "@/lib/actions/managed-teams";
 import { ManagedTeamsList } from "@/components/settings/managed-teams-list";
+import { AvailabilityGuardSettings } from "@/components/settings/availability-guard-settings";
+import { getAvailabilityGuardPolicy } from "@/lib/actions/settings";
+import { requireTenantId } from "@/lib/tenant";
+import { createClient } from "@/lib/supabase/server";
 import { getTranslations } from "next-intl/server";
 
 async function ManagedTeamsLoader() {
   const teams = await getManagedTeams();
   return <ManagedTeamsList initialTeams={teams} />;
+}
+
+async function AvailabilityGuardSettingsLoader() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const tenantId = await requireTenantId();
+  const [policy, membership] = await Promise.all([
+    getAvailabilityGuardPolicy(),
+    supabase
+      .from("organization_members")
+      .select("role")
+      .eq("organization_id", tenantId)
+      .eq("user_id", user.id)
+      .maybeSingle(),
+  ]);
+
+  if (membership.error) throw new Error(membership.error.message);
+
+  return (
+    <AvailabilityGuardSettings
+      initialPolicy={policy}
+      canEdit={membership.data?.role === "planner"}
+    />
+  );
 }
 
 export default async function SettingsPage() {
@@ -21,6 +53,14 @@ export default async function SettingsPage() {
         <h2 className="mb-4 text-lg font-semibold">{t("managedTeams")}</h2>
         <Suspense fallback={<TableSkeleton rows={3} cols={3} />}>
           <ManagedTeamsLoader />
+        </Suspense>
+      </div>
+      <div>
+        <h2 className="mb-4 text-lg font-semibold">
+          {t("guardPolicySection")}
+        </h2>
+        <Suspense fallback={<TableSkeleton rows={2} cols={1} />}>
+          <AvailabilityGuardSettingsLoader />
         </Suspense>
       </div>
     </div>

--- a/app/protected/settings/page.tsx
+++ b/app/protected/settings/page.tsx
@@ -3,9 +3,12 @@ import { TableSkeleton } from "@/components/skeletons";
 import { getManagedTeams } from "@/lib/actions/managed-teams";
 import { ManagedTeamsList } from "@/components/settings/managed-teams-list";
 import { AvailabilityGuardSettings } from "@/components/settings/availability-guard-settings";
-import { getAvailabilityGuardPolicy } from "@/lib/actions/settings";
 import { requireTenantId } from "@/lib/tenant";
 import { createClient } from "@/lib/supabase/server";
+import {
+  AVAILABILITY_GUARD_POLICIES,
+  type AvailabilityGuardPolicy,
+} from "@/lib/types/availability";
 import { getTranslations } from "next-intl/server";
 
 async function ManagedTeamsLoader() {
@@ -21,8 +24,12 @@ async function AvailabilityGuardSettingsLoader() {
   if (!user) throw new Error("Not authenticated");
 
   const tenantId = await requireTenantId();
-  const [policy, membership] = await Promise.all([
-    getAvailabilityGuardPolicy(),
+  const [settings, membership] = await Promise.all([
+    supabase
+      .from("organization_settings")
+      .select("availability_guard_policy")
+      .eq("organization_id", tenantId)
+      .maybeSingle(),
     supabase
       .from("organization_members")
       .select("role")
@@ -31,7 +38,16 @@ async function AvailabilityGuardSettingsLoader() {
       .maybeSingle(),
   ]);
 
+  if (settings.error) throw new Error(settings.error.message);
   if (membership.error) throw new Error(membership.error.message);
+
+  const policy =
+    settings.data?.availability_guard_policy &&
+    AVAILABILITY_GUARD_POLICIES.includes(
+      settings.data.availability_guard_policy as AvailabilityGuardPolicy,
+    )
+      ? (settings.data.availability_guard_policy as AvailabilityGuardPolicy)
+      : "warn";
 
   return (
     <AvailabilityGuardSettings

--- a/components/__tests__/availability-form.test.tsx
+++ b/components/__tests__/availability-form.test.tsx
@@ -33,6 +33,8 @@ const defaultProps = {
   umpireName: "Jan",
   slots,
   existingResponses: [] as AvailabilityResponse[],
+  guardPolicy: "warn" as const,
+  assignedSlotIds: [] as string[],
 };
 
 describe("AvailabilityForm", () => {
@@ -62,7 +64,7 @@ describe("AvailabilityForm", () => {
   });
 
   it("submits selected responses", async () => {
-    mockSubmit.mockResolvedValue(undefined);
+    mockSubmit.mockResolvedValue({ status: "saved" });
     render(<AvailabilityForm {...defaultProps} />);
 
     // Select Yes for slot 1
@@ -77,15 +79,21 @@ describe("AvailabilityForm", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
     await waitFor(() => {
-      expect(mockSubmit).toHaveBeenCalledWith("poll-1", "ump-1", "Jan", [
-        { slotId: "slot-1", response: "yes" },
-        { slotId: "slot-2", response: "no" },
-      ]);
+      expect(mockSubmit).toHaveBeenCalledWith(
+        "poll-1",
+        "ump-1",
+        "Jan",
+        [
+          { slotId: "slot-1", response: "yes" },
+          { slotId: "slot-2", response: "no" },
+        ],
+        { confirmAssignedDowngrade: false },
+      );
     });
   });
 
   it("shows success message after save", async () => {
-    mockSubmit.mockResolvedValue(undefined);
+    mockSubmit.mockResolvedValue({ status: "saved" });
     render(<AvailabilityForm {...defaultProps} />);
 
     fireEvent.click(screen.getAllByRole("button", { name: "Yes" })[0]);
@@ -199,6 +207,90 @@ describe("AvailabilityForm", () => {
       expect(screen.getByText("Poll is closed")).toBeTruthy();
     });
   });
+
+  it("shows confirmation dialog when server requires assigned-slot downgrade confirm", async () => {
+    mockSubmit
+      .mockResolvedValueOnce({
+        status: "confirm_required",
+        affectedSlots: ["slot-1"],
+      })
+      .mockResolvedValueOnce({ status: "saved" });
+
+    const existing: AvailabilityResponse[] = [
+      {
+        id: "resp-1",
+        poll_id: "poll-1",
+        slot_id: "slot-1",
+        participant_name: "Jan",
+        response: "yes",
+        umpire_id: "ump-1",
+        created_at: "2030-02-01T00:00:00Z",
+        updated_at: "2030-02-01T00:00:00Z",
+      },
+    ];
+
+    render(
+      <AvailabilityForm
+        {...defaultProps}
+        existingResponses={existing}
+        guardPolicy="warn"
+        assignedSlotIds={["slot-1"]}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "No" })[0]);
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Assigned match warning")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark unavailable" }));
+
+    await waitFor(() => {
+      expect(mockSubmit).toHaveBeenNthCalledWith(
+        2,
+        "poll-1",
+        "ump-1",
+        "Jan",
+        [
+          { slotId: "slot-1", response: "no" },
+          { slotId: "slot-2", response: null },
+        ],
+        { confirmAssignedDowngrade: true },
+      );
+    });
+  });
+
+  it("disables downgrade controls for assigned slots in block mode", () => {
+    const existing: AvailabilityResponse[] = [
+      {
+        id: "resp-1",
+        poll_id: "poll-1",
+        slot_id: "slot-1",
+        participant_name: "Jan",
+        response: "yes",
+        umpire_id: "ump-1",
+        created_at: "2030-02-01T00:00:00Z",
+        updated_at: "2030-02-01T00:00:00Z",
+      },
+    ];
+
+    render(
+      <AvailabilityForm
+        {...defaultProps}
+        existingResponses={existing}
+        guardPolicy="block"
+        assignedSlotIds={["slot-1"]}
+      />,
+    );
+
+    expect(screen.getAllByRole("button", { name: "No" })[0]).toBeDisabled();
+    expect(screen.getAllByRole("button", { name: "Yes" })[0]).toBeDisabled();
+    expect(
+      screen.getAllByRole("button", { name: "If need be" })[0],
+    ).not.toBeDisabled();
+  });
 });
 
 /* ------------------------------------------------------------------ */
@@ -241,6 +333,8 @@ const pastFutureProps = {
   umpireId: "ump-1",
   umpireName: "Jan",
   existingResponses: [] as AvailabilityResponse[],
+  guardPolicy: "warn" as const,
+  assignedSlotIds: [] as string[],
 };
 
 describe("AvailabilityForm – past/future partitioning", () => {
@@ -362,7 +456,7 @@ describe("AvailabilityForm – past/future partitioning", () => {
   });
 
   it("does not include past slot responses in submission", async () => {
-    mockSubmit.mockResolvedValue(undefined);
+    mockSubmit.mockResolvedValue({ status: "saved" });
 
     const existingResponses: AvailabilityResponse[] = [
       {
@@ -391,9 +485,13 @@ describe("AvailabilityForm – past/future partitioning", () => {
     fireEvent.click(screen.getByText("Save changes"));
 
     await waitFor(() => {
-      expect(mockSubmit).toHaveBeenCalledWith("poll-1", "ump-1", "Jan", [
-        { slotId: "future-1", response: "yes" },
-      ]);
+      expect(mockSubmit).toHaveBeenCalledWith(
+        "poll-1",
+        "ump-1",
+        "Jan",
+        [{ slotId: "future-1", response: "yes" }],
+        { confirmAssignedDowngrade: false },
+      );
     });
   });
 

--- a/components/__tests__/dashboard.test.tsx
+++ b/components/__tests__/dashboard.test.tsx
@@ -146,6 +146,27 @@ describe("RecentActivitySection", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders availability warning events prominently", async () => {
+    vi.mocked(getRecentActivity).mockResolvedValue([
+      {
+        type: "availability_warning",
+        umpire: "Jan",
+        pollTitle: "Weekend Poll",
+        outcome: "blocked",
+        timestamp: new Date().toISOString(),
+      },
+    ]);
+
+    const jsx = await RecentActivitySection();
+    render(jsx);
+
+    const message = screen.getByText(
+      "Availability blocked: Jan could not set assigned-slot availability to unavailable in Weekend Poll",
+    );
+    expect(message).toBeInTheDocument();
+    expect(message.closest("li")?.className).toContain("border-amber-300");
+  });
+
   it("shows 'No recent activity' when there are no events", async () => {
     vi.mocked(getRecentActivity).mockResolvedValue([]);
 

--- a/components/__tests__/poll-response-page-integration.test.tsx
+++ b/components/__tests__/poll-response-page-integration.test.tsx
@@ -7,6 +7,7 @@ import type { Poll, PollSlot } from "@/lib/types/domain";
 vi.mock("@/lib/actions/public-polls", () => ({
   findUmpireById: vi.fn(),
   getMyResponses: vi.fn(),
+  getAvailabilityGuardStatus: vi.fn(),
   findOrCreateUmpire: vi.fn(),
   submitResponses: vi.fn(),
 }));
@@ -24,10 +25,15 @@ vi.mock("@/lib/supabase/client", () => ({
   }),
 }));
 
-import { findUmpireById, getMyResponses } from "@/lib/actions/public-polls";
+import {
+  findUmpireById,
+  getMyResponses,
+  getAvailabilityGuardStatus,
+} from "@/lib/actions/public-polls";
 
 const mockFindUmpireById = vi.mocked(findUmpireById);
 const mockGetMyResponses = vi.mocked(getMyResponses);
+const mockGetAvailabilityGuardStatus = vi.mocked(getAvailabilityGuardStatus);
 
 const openPoll: Poll = {
   id: "poll-1",
@@ -56,6 +62,10 @@ const slots: PollSlot[] = [
 describe("PollResponsePage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetAvailabilityGuardStatus.mockResolvedValue({
+      policy: "warn",
+      assignedSlotIds: [],
+    });
     // Clear the umpire cookie
     document.cookie =
       "fluitplanner_umpire_id=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";

--- a/components/dashboard/recent-activity-section.tsx
+++ b/components/dashboard/recent-activity-section.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatDistanceToNow } from "date-fns";
 import { nl } from "date-fns/locale";
 import { getTranslations, getLocale } from "next-intl/server";
+import { AlertTriangle } from "lucide-react";
 
 function formatEvent(
   event: ActivityEvent,
@@ -29,6 +30,17 @@ function formatEvent(
       });
     case "matches_batch":
       return t("activityMatchesBatch", { count: event.count });
+    case "availability_warning":
+      if (event.outcome === "blocked") {
+        return t("activityAvailabilityBlocked", {
+          umpire: event.umpire,
+          pollTitle: event.pollTitle,
+        });
+      }
+      return t("activityAvailabilityWarned", {
+        umpire: event.umpire,
+        pollTitle: event.pollTitle,
+      });
   }
 }
 
@@ -50,8 +62,20 @@ export async function RecentActivitySection() {
         ) : (
           <ul className="flex flex-col gap-3">
             {events.map((event, i) => (
-              <li key={i} className="flex items-center justify-between text-sm">
-                <span>{formatEvent(event, t)}</span>
+              <li
+                key={i}
+                className={`flex items-center justify-between text-sm ${
+                  event.type === "availability_warning"
+                    ? "rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-amber-900"
+                    : ""
+                }`}
+              >
+                <span className="flex items-center gap-2">
+                  {event.type === "availability_warning" && (
+                    <AlertTriangle className="h-4 w-4 shrink-0 text-amber-700" />
+                  )}
+                  {formatEvent(event, t)}
+                </span>
                 <span className="text-muted-foreground text-xs whitespace-nowrap ml-4">
                   {formatDistanceToNow(new Date(event.timestamp), {
                     addSuffix: true,

--- a/components/dashboard/recent-activity-section.tsx
+++ b/components/dashboard/recent-activity-section.tsx
@@ -4,6 +4,7 @@ import { formatDistanceToNow } from "date-fns";
 import { nl } from "date-fns/locale";
 import { getTranslations, getLocale } from "next-intl/server";
 import { AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 function formatEvent(
   event: ActivityEvent,
@@ -44,6 +45,14 @@ function formatEvent(
   }
 }
 
+function getEventItemClass(event: ActivityEvent): string {
+  return cn(
+    "flex items-center justify-between text-sm",
+    event.type === "availability_warning" &&
+      "rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-amber-900",
+  );
+}
+
 export async function RecentActivitySection() {
   const t = await getTranslations("dashboard");
   const locale = await getLocale();
@@ -62,14 +71,7 @@ export async function RecentActivitySection() {
         ) : (
           <ul className="flex flex-col gap-3">
             {events.map((event, i) => (
-              <li
-                key={i}
-                className={`flex items-center justify-between text-sm ${
-                  event.type === "availability_warning"
-                    ? "rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-amber-900"
-                    : ""
-                }`}
-              >
+              <li key={i} className={getEventItemClass(event)}>
                 <span className="flex items-center gap-2">
                   {event.type === "availability_warning" && (
                     <AlertTriangle className="h-4 w-4 shrink-0 text-amber-700" />

--- a/components/poll-response/availability-form.tsx
+++ b/components/poll-response/availability-form.tsx
@@ -4,10 +4,7 @@ import { useState, useRef, useEffect, useMemo } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { SlotRow } from "@/components/poll-response/slot-row";
 import { StickyDirtyBar } from "@/components/poll-response/sticky-dirty-bar";
-import {
-  submitResponses,
-  type AvailabilityGuardPolicy,
-} from "@/lib/actions/public-polls";
+import { submitResponses } from "@/lib/actions/public-polls";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -20,6 +17,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useTranslations, useFormatter } from "next-intl";
 import type { PollSlot, AvailabilityResponse } from "@/lib/types/domain";
+import type { AvailabilityGuardPolicy } from "@/lib/types/availability";
 
 type ResponseValue = "yes" | "if_need_be" | "no";
 

--- a/components/poll-response/availability-form.tsx
+++ b/components/poll-response/availability-form.tsx
@@ -4,7 +4,20 @@ import { useState, useRef, useEffect, useMemo } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { SlotRow } from "@/components/poll-response/slot-row";
 import { StickyDirtyBar } from "@/components/poll-response/sticky-dirty-bar";
-import { submitResponses } from "@/lib/actions/public-polls";
+import {
+  submitResponses,
+  type AvailabilityGuardPolicy,
+} from "@/lib/actions/public-polls";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { useTranslations, useFormatter } from "next-intl";
 import type { PollSlot, AvailabilityResponse } from "@/lib/types/domain";
 
@@ -16,6 +29,8 @@ type Props = {
   umpireName: string;
   slots: PollSlot[];
   existingResponses: AvailabilityResponse[];
+  guardPolicy: AvailabilityGuardPolicy;
+  assignedSlotIds: string[];
 };
 
 export function AvailabilityForm({
@@ -24,6 +39,8 @@ export function AvailabilityForm({
   umpireName,
   slots,
   existingResponses,
+  guardPolicy,
+  assignedSlotIds,
 }: Props) {
   const t = useTranslations("pollResponse");
   const format = useFormatter();
@@ -31,6 +48,10 @@ export function AvailabilityForm({
   // Capture "now" once on mount so slots don't shuffle between past/future on re-renders
   const mountTimeRef = useRef(new Date());
   const now = mountTimeRef.current;
+  const assignedSlotSet = useMemo(
+    () => new Set(assignedSlotIds),
+    [assignedSlotIds],
+  );
 
   function formatDateHeading(isoString: string): string {
     return format.dateTime(new Date(isoString), {
@@ -90,7 +111,9 @@ export function AvailabilityForm({
   const [saving, setSaving] = useState(false);
   const [showSavedInBar, setShowSavedInBar] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [showPastDates, setShowPastDates] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   const [savedBaseline, setSavedBaseline] =
     useState<Record<string, ResponseValue | null>>(initialState);
@@ -124,24 +147,59 @@ export function AvailabilityForm({
   function handleChange(slotId: string, value: ResponseValue | null) {
     setResponses((prev) => ({ ...prev, [slotId]: value }));
     setError(null);
+    setStatusMessage(null);
   }
 
-  // Only consider future slots for save button enable state
-  const hasSelections = Array.from(futureSlotIds).some(
-    (id) => responses[id] !== null,
-  );
-
-  async function handleSubmit(e?: React.FormEvent) {
-    if (e) e.preventDefault();
+  async function runSubmit(confirmAssignedDowngrade = false) {
     setSaving(true);
     setError(null);
-    // Only submit responses for future slots
-    const toSubmit = Object.entries(responses)
-      .filter(([slotId, value]) => value !== null && futureSlotIds.has(slotId))
-      .map(([slotId, response]) => ({ slotId, response: response! }));
+    setStatusMessage(null);
+
+    const toSubmit = Array.from(futureSlotIds).map((slotId) => ({
+      slotId,
+      response: responses[slotId],
+    }));
+
     try {
-      await submitResponses(pollId, umpireId, umpireName, toSubmit);
-      setSavedBaseline({ ...responses });
+      const result = await submitResponses(
+        pollId,
+        umpireId,
+        umpireName,
+        toSubmit,
+        { confirmAssignedDowngrade },
+      );
+
+      if (result.status === "confirm_required") {
+        setConfirmOpen(true);
+        return;
+      }
+
+      if (result.status === "partial_saved") {
+        const blockedSet = new Set(result.blockedSlots);
+        const nextBaseline: Record<string, ResponseValue | null> = {
+          ...savedBaseline,
+        };
+        const nextResponses: Record<string, ResponseValue | null> = {
+          ...responses,
+        };
+
+        for (const slotId of futureSlotIds) {
+          if (blockedSet.has(slotId)) {
+            nextResponses[slotId] = savedBaseline[slotId];
+            continue;
+          }
+          nextBaseline[slotId] = responses[slotId];
+        }
+
+        setResponses(nextResponses);
+        setSavedBaseline(nextBaseline);
+        setStatusMessage(
+          t("guardBlockedPartialSaved", { count: result.blockedSlots.length }),
+        );
+      } else {
+        setSavedBaseline({ ...responses });
+      }
+
       setShowSavedInBar(true);
       if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
       savedTimerRef.current = setTimeout(() => setShowSavedInBar(false), 2000);
@@ -150,6 +208,11 @@ export function AvailabilityForm({
     } finally {
       setSaving(false);
     }
+  }
+
+  async function handleSubmit(e?: React.FormEvent) {
+    if (e) e.preventDefault();
+    await runSubmit(false);
   }
 
   const barVisible = isDirty || saving || showSavedInBar || error !== null;
@@ -165,78 +228,120 @@ export function AvailabilityForm({
           {group.label}
         </div>
         <div className="px-3">
-          {group.slots.map((slot) => (
-            <SlotRow
-              key={slot.id}
-              startTime={slot.start_time}
-              endTime={slot.end_time}
-              value={responses[slot.id]}
-              onChange={(value) => handleChange(slot.id, value)}
-              disabled={disabled}
-            />
-          ))}
+          {group.slots.map((slot) => {
+            const isAssigned = assignedSlotSet.has(slot.id);
+            const value = responses[slot.id];
+            const downgradeBlocked =
+              guardPolicy === "block" &&
+              isAssigned &&
+              (value === "yes" || value === "if_need_be");
+
+            return (
+              <SlotRow
+                key={slot.id}
+                startTime={slot.start_time}
+                endTime={slot.end_time}
+                value={value}
+                onChange={(nextValue) => handleChange(slot.id, nextValue)}
+                disabled={disabled}
+                disabledValues={downgradeBlocked ? ["no"] : []}
+                disableClear={downgradeBlocked}
+              />
+            );
+          })}
         </div>
       </div>
     );
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      {/* Edge case: all slots in past */}
-      {allSlotsInPast && (
-        <div className="bg-muted text-muted-foreground rounded-md px-3 py-4 text-center text-sm">
-          {t("allDatesInPast")}
-        </div>
-      )}
+    <>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {/* Edge case: all slots in past */}
+        {allSlotsInPast && (
+          <div className="bg-muted text-muted-foreground rounded-md px-3 py-4 text-center text-sm">
+            {t("allDatesInPast")}
+          </div>
+        )}
 
-      {/* Future date groups (editable) */}
-      {futureDateGroups.map((group) => renderDateGroup(group))}
+        {/* Future date groups (editable) */}
+        {futureDateGroups.map((group) => renderDateGroup(group))}
 
-      {/* When all slots are past, show them expanded (no toggle) */}
-      {allSlotsInPast && (
-        <div className="space-y-4">
-          {pastDateGroups.map((group) => renderDateGroup(group, true))}
-        </div>
-      )}
+        {/* When all slots are past, show them expanded (no toggle) */}
+        {allSlotsInPast && (
+          <div className="space-y-4">
+            {pastDateGroups.map((group) => renderDateGroup(group, true))}
+          </div>
+        )}
 
-      {/* Past dates toggle + collapsible section (only when there are also future slots) */}
-      {hasPastSlots && !allSlotsInPast && (
-        <div>
-          <button
-            type="button"
-            onClick={() => setShowPastDates((prev) => !prev)}
-            className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 px-3 py-2 text-sm"
-          >
-            {showPastDates ? (
-              <ChevronDown className="h-4 w-4" />
-            ) : (
-              <ChevronRight className="h-4 w-4" />
+        {/* Past dates toggle + collapsible section (only when there are also future slots) */}
+        {hasPastSlots && !allSlotsInPast && (
+          <div>
+            <button
+              type="button"
+              onClick={() => setShowPastDates((prev) => !prev)}
+              className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 px-3 py-2 text-sm"
+            >
+              {showPastDates ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+              {t("pastDatesToggle", { count: pastDateGroups.length })}
+            </button>
+
+            {showPastDates && (
+              <div className="space-y-4">
+                {pastDateGroups.map((group) => renderDateGroup(group, true))}
+              </div>
             )}
-            {t("pastDatesToggle", { count: pastDateGroups.length })}
-          </button>
+          </div>
+        )}
 
-          {showPastDates && (
-            <div className="space-y-4">
-              {pastDateGroups.map((group) => renderDateGroup(group, true))}
-            </div>
-          )}
-        </div>
-      )}
+        {statusMessage && (
+          <p className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+            {statusMessage}
+          </p>
+        )}
 
-      {/* Save bar — only when there are future slots to save */}
-      {!allSlotsInPast && (
-        <>
-          <div className="h-16" />
-          <StickyDirtyBar
-            visible={barVisible}
-            saving={saving}
-            saved={showSavedInBar && !isDirty}
-            error={error}
-            disabled={!hasSelections || saving}
-            onSave={() => handleSubmit()}
-          />
-        </>
-      )}
-    </form>
+        {/* Save bar — only when there are future slots to save */}
+        {!allSlotsInPast && (
+          <>
+            <div className="h-16" />
+            <StickyDirtyBar
+              visible={barVisible}
+              saving={saving}
+              saved={showSavedInBar && !isDirty}
+              error={error}
+              disabled={!isDirty || saving}
+              onSave={() => handleSubmit()}
+            />
+          </>
+        )}
+      </form>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("guardConfirmTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("guardConfirmDescription")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("guardConfirmCancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={async (event) => {
+                event.preventDefault();
+                setConfirmOpen(false);
+                await runSubmit(true);
+              }}
+            >
+              {t("guardConfirmProceed")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/components/poll-response/poll-response-page.tsx
+++ b/components/poll-response/poll-response-page.tsx
@@ -6,7 +6,12 @@ import { AvailabilityForm } from "@/components/poll-response/availability-form";
 import { UmpireIdentifier } from "@/components/poll-response/umpire-identifier";
 import { VerificationForm } from "@/components/poll-response/verification-form";
 import { createClient } from "@/lib/supabase/client";
-import { findUmpireById, getMyResponses } from "@/lib/actions/public-polls";
+import {
+  findUmpireById,
+  getMyResponses,
+  getAvailabilityGuardStatus,
+  type AvailabilityGuardPolicy,
+} from "@/lib/actions/public-polls";
 import { verifyMagicLink } from "@/lib/actions/verification";
 import { LayoutDashboard } from "lucide-react";
 import Link from "next/link";
@@ -66,6 +71,9 @@ export function PollResponsePage({
   const [existingResponses, setExistingResponses] = useState<
     AvailabilityResponse[]
   >([]);
+  const [guardPolicy, setGuardPolicy] =
+    useState<AvailabilityGuardPolicy>("warn");
+  const [assignedSlotIds, setAssignedSlotIds] = useState<string[]>([]);
   const [verifyState, setVerifyState] = useState<{
     email: string;
     maskedEmail: string;
@@ -85,8 +93,13 @@ export function PollResponsePage({
         const result = await verifyMagicLink(verifyToken);
         if ("umpire" in result) {
           setCookie(COOKIE_NAME, result.umpire.id, 365);
-          const responses = await getMyResponses(poll.id, result.umpire.id);
+          const [responses, guardStatus] = await Promise.all([
+            getMyResponses(poll.id, result.umpire.id),
+            getAvailabilityGuardStatus(poll.id, result.umpire.id),
+          ]);
           setExistingResponses(responses);
+          setGuardPolicy(guardStatus.policy);
+          setAssignedSlotIds(guardStatus.assignedSlotIds);
           setUmpire(result.umpire);
           setLoading(false);
           return;
@@ -98,8 +111,13 @@ export function PollResponsePage({
       if (savedId) {
         const found = await findUmpireById(savedId);
         if (found) {
-          const responses = await getMyResponses(poll.id, found.id);
+          const [responses, guardStatus] = await Promise.all([
+            getMyResponses(poll.id, found.id),
+            getAvailabilityGuardStatus(poll.id, found.id),
+          ]);
           setExistingResponses(responses);
+          setGuardPolicy(guardStatus.policy);
+          setAssignedSlotIds(guardStatus.assignedSlotIds);
           setUmpire(found);
         } else {
           deleteCookie(COOKIE_NAME);
@@ -112,8 +130,13 @@ export function PollResponsePage({
 
   async function handleIdentified(identified: Umpire) {
     setCookie(COOKIE_NAME, identified.id, 365);
-    const responses = await getMyResponses(poll.id, identified.id);
+    const [responses, guardStatus] = await Promise.all([
+      getMyResponses(poll.id, identified.id),
+      getAvailabilityGuardStatus(poll.id, identified.id),
+    ]);
     setExistingResponses(responses);
+    setGuardPolicy(guardStatus.policy);
+    setAssignedSlotIds(guardStatus.assignedSlotIds);
     setUmpire(identified);
   }
 
@@ -233,6 +256,8 @@ export function PollResponsePage({
         umpireName={umpire.name}
         slots={slots}
         existingResponses={existingResponses}
+        guardPolicy={guardPolicy}
+        assignedSlotIds={assignedSlotIds}
       />
     </div>
   );

--- a/components/poll-response/poll-response-page.tsx
+++ b/components/poll-response/poll-response-page.tsx
@@ -10,12 +10,12 @@ import {
   findUmpireById,
   getMyResponses,
   getAvailabilityGuardStatus,
-  type AvailabilityGuardPolicy,
 } from "@/lib/actions/public-polls";
 import { verifyMagicLink } from "@/lib/actions/verification";
 import { LayoutDashboard } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
+import type { AvailabilityGuardPolicy } from "@/lib/types/availability";
 import type {
   AvailabilityResponse,
   Poll,
@@ -149,6 +149,8 @@ export function PollResponsePage({
     setUmpire(null);
     setVerifyState(null);
     setExistingResponses([]);
+    setGuardPolicy("warn");
+    setAssignedSlotIds([]);
   }
 
   /* Loading */

--- a/components/poll-response/slot-row.tsx
+++ b/components/poll-response/slot-row.tsx
@@ -12,6 +12,8 @@ type Props = {
   value: ResponseValue | null;
   onChange: (value: ResponseValue | null) => void;
   disabled?: boolean;
+  disabledValues?: ResponseValue[];
+  disableClear?: boolean;
 };
 
 type ButtonConfig = {
@@ -45,6 +47,8 @@ export function SlotRow({
   value,
   onChange,
   disabled,
+  disabledValues = [],
+  disableClear = false,
 }: Props) {
   const t = useTranslations("pollResponse");
   const format = useFormatter();
@@ -76,7 +80,11 @@ export function SlotRow({
             size="sm"
             className={value === btn.value ? btn.activeClass : ""}
             onClick={() => onChange(value === btn.value ? null : btn.value)}
-            disabled={disabled}
+            disabled={
+              disabled ||
+              disabledValues.includes(btn.value) ||
+              (disableClear && value === btn.value)
+            }
           >
             {t(btn.labelKey)}
           </Button>

--- a/components/settings/availability-guard-settings.tsx
+++ b/components/settings/availability-guard-settings.tsx
@@ -1,14 +1,12 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import {
-  updateAvailabilityGuardPolicy,
-  type AvailabilityGuardPolicy,
-} from "@/lib/actions/settings";
+import { updateAvailabilityGuardPolicy } from "@/lib/actions/settings";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { useTranslations } from "next-intl";
+import type { AvailabilityGuardPolicy } from "@/lib/types/availability";
 
 type Props = {
   initialPolicy: AvailabilityGuardPolicy;
@@ -53,6 +51,7 @@ export function AvailabilityGuardSettings({ initialPolicy, canEdit }: Props) {
         onValueChange={(value) => {
           setPolicy(value as AvailabilityGuardPolicy);
           setSaved(false);
+          setError(null);
         }}
         disabled={!canEdit || isPending}
         className="space-y-3"
@@ -95,7 +94,9 @@ export function AvailabilityGuardSettings({ initialPolicy, canEdit }: Props) {
           </p>
         )}
         {saved && (
-          <p className="text-sm text-green-600">{t("guardPolicySaved")}</p>
+          <p className="text-sm text-emerald-600 dark:text-emerald-400">
+            {t("guardPolicySaved")}
+          </p>
         )}
       </div>
 

--- a/components/settings/availability-guard-settings.tsx
+++ b/components/settings/availability-guard-settings.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  updateAvailabilityGuardPolicy,
+  type AvailabilityGuardPolicy,
+} from "@/lib/actions/settings";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { useTranslations } from "next-intl";
+
+type Props = {
+  initialPolicy: AvailabilityGuardPolicy;
+  canEdit: boolean;
+};
+
+export function AvailabilityGuardSettings({ initialPolicy, canEdit }: Props) {
+  const t = useTranslations("settings");
+  const [policy, setPolicy] = useState<AvailabilityGuardPolicy>(initialPolicy);
+  const [savedPolicy, setSavedPolicy] =
+    useState<AvailabilityGuardPolicy>(initialPolicy);
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  const isDirty = policy !== savedPolicy;
+
+  function handleSave() {
+    setError(null);
+    setSaved(false);
+
+    startTransition(async () => {
+      try {
+        await updateAvailabilityGuardPolicy(policy);
+        setSavedPolicy(policy);
+        setSaved(true);
+      } catch {
+        setError(t("guardPolicyError"));
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-base font-semibold">{t("guardPolicyTitle")}</h3>
+        <p className="text-muted-foreground text-sm">{t("guardPolicyHelp")}</p>
+      </div>
+
+      <RadioGroup
+        value={policy}
+        onValueChange={(value) => {
+          setPolicy(value as AvailabilityGuardPolicy);
+          setSaved(false);
+        }}
+        disabled={!canEdit || isPending}
+        className="space-y-3"
+      >
+        <div className="flex items-start gap-3 rounded-md border p-3">
+          <RadioGroupItem value="warn" id="guard-policy-warn" />
+          <div className="space-y-1">
+            <Label htmlFor="guard-policy-warn">
+              {t("guardPolicyWarnLabel")}
+            </Label>
+            <p className="text-muted-foreground text-sm">
+              {t("guardPolicyWarnHelp")}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-start gap-3 rounded-md border p-3">
+          <RadioGroupItem value="block" id="guard-policy-block" />
+          <div className="space-y-1">
+            <Label htmlFor="guard-policy-block">
+              {t("guardPolicyBlockLabel")}
+            </Label>
+            <p className="text-muted-foreground text-sm">
+              {t("guardPolicyBlockHelp")}
+            </p>
+          </div>
+        </div>
+      </RadioGroup>
+
+      <div className="flex items-center gap-3">
+        <Button
+          type="button"
+          onClick={handleSave}
+          disabled={!canEdit || !isDirty || isPending}
+        >
+          {isPending ? t("guardPolicySaving") : t("guardPolicySave")}
+        </Button>
+        {!canEdit && (
+          <p className="text-muted-foreground text-sm">
+            {t("guardPolicyReadOnly")}
+          </p>
+        )}
+        {saved && (
+          <p className="text-sm text-green-600">{t("guardPolicySaved")}</p>
+        )}
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/lib/actions/dashboard.ts
+++ b/lib/actions/dashboard.ts
@@ -50,6 +50,13 @@ export type ActivityEvent =
       type: "matches_batch";
       count: number;
       timestamp: string;
+    }
+  | {
+      type: "availability_warning";
+      umpire: string;
+      pollTitle: string;
+      outcome: "confirm_required" | "blocked";
+      timestamp: string;
     };
 
 /* ------------------------------------------------------------------ */
@@ -464,8 +471,40 @@ export async function getRecentActivity(): Promise<ActivityEvent[]> {
     };
   });
 
+  // 4. Availability downgrade warnings
+  const { data: warnings, error: warningError } = await supabase
+    .from("availability_change_warnings")
+    .select("created_at, outcome, umpires(name), polls(title)")
+    .eq("organization_id", tenantId)
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (warningError) throw new Error(warningError.message);
+
+  const warningEvents: ActivityEvent[] = (warnings ?? []).map((warning) => {
+    const umpire = Array.isArray(warning.umpires)
+      ? warning.umpires[0]
+      : warning.umpires;
+    const poll = Array.isArray(warning.polls)
+      ? warning.polls[0]
+      : warning.polls;
+
+    return {
+      type: "availability_warning",
+      umpire: umpire?.name ?? "Umpire",
+      pollTitle: poll?.title ?? "poll",
+      outcome: warning.outcome as "confirm_required" | "blocked",
+      timestamp: warning.created_at,
+    };
+  });
+
   // Merge, sort descending, limit 10
-  const allEvents = [...responseEvents, ...assignmentEvents, ...matchEvents];
+  const allEvents = [
+    ...responseEvents,
+    ...assignmentEvents,
+    ...matchEvents,
+    ...warningEvents,
+  ];
   allEvents.sort(
     (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
   );

--- a/lib/actions/dashboard.ts
+++ b/lib/actions/dashboard.ts
@@ -59,6 +59,11 @@ export type ActivityEvent =
       timestamp: string;
     };
 
+const VALID_WARNING_OUTCOMES = new Set([
+  "confirm_required",
+  "blocked",
+] as const);
+
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                            */
 /* ------------------------------------------------------------------ */
@@ -489,11 +494,19 @@ export async function getRecentActivity(): Promise<ActivityEvent[]> {
       ? warning.polls[0]
       : warning.polls;
 
+    const outcome =
+      typeof warning.outcome === "string" &&
+      VALID_WARNING_OUTCOMES.has(
+        warning.outcome as "confirm_required" | "blocked",
+      )
+        ? (warning.outcome as "confirm_required" | "blocked")
+        : "confirm_required";
+
     return {
       type: "availability_warning",
       umpire: umpire?.name ?? "Umpire",
       pollTitle: poll?.title ?? "poll",
-      outcome: warning.outcome as "confirm_required" | "blocked",
+      outcome,
       timestamp: warning.created_at,
     };
   });

--- a/lib/actions/public-polls.ts
+++ b/lib/actions/public-polls.ts
@@ -2,11 +2,14 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { getTenantId } from "@/lib/tenant";
+import { mapMatchesToSlots } from "@/lib/domain/match-slot-mapping";
+import { createServiceClient } from "@/lib/supabase/service";
 import type {
   Poll,
   PollSlot,
   Umpire,
   AvailabilityResponse,
+  Match,
 } from "@/lib/types/domain";
 
 /* ------------------------------------------------------------------ */
@@ -20,8 +23,129 @@ export type PublicPollData = {
 
 export type ResponseInput = {
   slotId: string;
-  response: "yes" | "if_need_be" | "no";
+  response: "yes" | "if_need_be" | "no" | null;
 };
+
+export type SubmitResponsesResult =
+  | { status: "saved"; warningLogged?: boolean }
+  | { status: "confirm_required"; affectedSlots: string[] }
+  | { status: "partial_saved"; blockedSlots: string[] };
+
+export type AvailabilityGuardPolicy = "warn" | "block";
+
+export type AvailabilityGuardStatus = {
+  policy: AvailabilityGuardPolicy;
+  assignedSlotIds: string[];
+};
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function isDowngradeTransition(
+  from: AvailabilityResponse["response"] | null,
+  to: ResponseInput["response"],
+): boolean {
+  return (
+    (from === "yes" || from === "if_need_be") && (to === "no" || to === null)
+  );
+}
+
+async function getGuardPolicyForOrganization(
+  organizationId: string,
+): Promise<AvailabilityGuardPolicy> {
+  const serviceClient = createServiceClient();
+  const { data, error } = await serviceClient
+    .from("organization_settings")
+    .select("availability_guard_policy")
+    .eq("organization_id", organizationId)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return (data?.availability_guard_policy ?? "warn") as AvailabilityGuardPolicy;
+}
+
+async function getAssignedSlotIds(
+  pollId: string,
+  umpireId: string,
+): Promise<Set<string>> {
+  const serviceClient = createServiceClient();
+
+  const { data: assignments, error: assignmentError } = await serviceClient
+    .from("assignments")
+    .select("match_id")
+    .eq("poll_id", pollId)
+    .eq("umpire_id", umpireId);
+
+  if (assignmentError) throw new Error(assignmentError.message);
+
+  const matchIds = (assignments ?? []).map(
+    (a: { match_id: string }) => a.match_id,
+  );
+  if (matchIds.length === 0) return new Set<string>();
+
+  const { data: matches, error: matchError } = await serviceClient
+    .from("matches")
+    .select(
+      "id, date, start_time, home_team, away_team, competition, venue, field, required_level, created_by, created_at, organization_id",
+    )
+    .in("id", matchIds);
+
+  if (matchError) throw new Error(matchError.message);
+
+  const { data: slots, error: slotError } = await serviceClient
+    .from("poll_slots")
+    .select("id, poll_id, start_time, end_time")
+    .eq("poll_id", pollId);
+
+  if (slotError) throw new Error(slotError.message);
+
+  const slotMap = mapMatchesToSlots(
+    (matches ?? []) as Match[],
+    (slots ?? []) as PollSlot[],
+  );
+
+  const assignedSlotIds = new Set<string>();
+  for (const matchId of matchIds) {
+    const slotId = slotMap.get(matchId);
+    if (slotId) assignedSlotIds.add(slotId);
+  }
+
+  return assignedSlotIds;
+}
+
+async function logAvailabilityWarnings(params: {
+  organizationId: string;
+  pollId: string;
+  umpireId: string;
+  policy: AvailabilityGuardPolicy;
+  outcome: "confirm_required" | "blocked";
+  transitions: Array<{
+    slotId: string;
+    from: "yes" | "if_need_be";
+    to: "no" | null;
+  }>;
+}): Promise<void> {
+  if (params.transitions.length === 0) return;
+
+  const serviceClient = createServiceClient();
+  const rows = params.transitions.map((t) => ({
+    organization_id: params.organizationId,
+    poll_id: params.pollId,
+    slot_id: t.slotId,
+    umpire_id: params.umpireId,
+    from_response: t.from,
+    to_response: t.to === null ? "none" : "no",
+    policy: params.policy,
+    outcome: params.outcome,
+  }));
+
+  const { error } = await serviceClient
+    .from("availability_change_warnings")
+    .insert(rows);
+
+  if (error) throw new Error(error.message);
+}
 
 /* ------------------------------------------------------------------ */
 /*  getPollByToken                                                     */
@@ -153,6 +277,36 @@ export async function getMyResponses(
   return data ?? [];
 }
 
+export async function getAvailabilityGuardStatus(
+  pollId: string,
+  umpireId: string,
+): Promise<AvailabilityGuardStatus> {
+  const supabase = await createClient();
+
+  const { data: poll, error } = await supabase
+    .from("polls")
+    .select("organization_id")
+    .eq("id", pollId)
+    .single();
+
+  if (error || !poll) {
+    return {
+      policy: "warn",
+      assignedSlotIds: [],
+    };
+  }
+
+  const [policy, assignedSlotIds] = await Promise.all([
+    getGuardPolicyForOrganization(poll.organization_id),
+    getAssignedSlotIds(pollId, umpireId),
+  ]);
+
+  return {
+    policy,
+    assignedSlotIds: Array.from(assignedSlotIds),
+  };
+}
+
 /* ------------------------------------------------------------------ */
 /*  submitResponses                                                    */
 /* ------------------------------------------------------------------ */
@@ -162,34 +316,159 @@ export async function submitResponses(
   umpireId: string,
   participantName: string,
   responses: ResponseInput[],
-): Promise<void> {
-  if (responses.length === 0) return;
-
+  options?: { confirmAssignedDowngrade?: boolean },
+): Promise<SubmitResponsesResult> {
   const supabase = await createClient();
 
-  // Verify poll is open
+  // Verify poll is open and get organization scope
   const { data: poll, error: pollError } = await supabase
     .from("polls")
-    .select("status")
+    .select("status, organization_id")
     .eq("id", pollId)
     .single();
 
   if (pollError || !poll) throw new Error("Poll not found");
   if (poll.status === "closed") throw new Error("Poll is closed");
 
-  // Upsert responses
-  const rows = responses.map((r) => ({
-    poll_id: pollId,
-    slot_id: r.slotId,
-    participant_name: participantName,
-    response: r.response,
-    umpire_id: umpireId,
-    updated_at: new Date().toISOString(),
-  }));
+  if (responses.length === 0) return { status: "saved" };
 
-  const { error } = await supabase
-    .from("availability_responses")
-    .upsert(rows, { onConflict: "poll_id,slot_id,umpire_id" });
+  const dedupedResponses = new Map<string, ResponseInput["response"]>();
+  for (const response of responses) {
+    dedupedResponses.set(response.slotId, response.response);
+  }
 
-  if (error) throw new Error(error.message);
+  const submittedSlotIds = Array.from(dedupedResponses.keys());
+
+  const [existingResponseRows, policy, assignedSlotIds] = await Promise.all([
+    supabase
+      .from("availability_responses")
+      .select("slot_id, response")
+      .eq("poll_id", pollId)
+      .eq("umpire_id", umpireId)
+      .in("slot_id", submittedSlotIds),
+    getGuardPolicyForOrganization(poll.organization_id),
+    getAssignedSlotIds(pollId, umpireId),
+  ]);
+
+  if (existingResponseRows.error) {
+    throw new Error(existingResponseRows.error.message);
+  }
+
+  const existingBySlot = new Map<string, AvailabilityResponse["response"]>();
+  for (const row of existingResponseRows.data ?? []) {
+    existingBySlot.set(
+      row.slot_id,
+      row.response as AvailabilityResponse["response"],
+    );
+  }
+
+  const conflictingTransitions: Array<{
+    slotId: string;
+    from: "yes" | "if_need_be";
+    to: "no" | null;
+  }> = [];
+
+  for (const [slotId, next] of dedupedResponses) {
+    const prev = existingBySlot.get(slotId) ?? null;
+    if (!assignedSlotIds.has(slotId)) continue;
+
+    if (isDowngradeTransition(prev, next)) {
+      conflictingTransitions.push({
+        slotId,
+        from: prev as "yes" | "if_need_be",
+        to: next as "no" | null,
+      });
+    }
+  }
+
+  if (
+    policy === "warn" &&
+    conflictingTransitions.length > 0 &&
+    !options?.confirmAssignedDowngrade
+  ) {
+    await logAvailabilityWarnings({
+      organizationId: poll.organization_id,
+      pollId,
+      umpireId,
+      policy,
+      outcome: "confirm_required",
+      transitions: conflictingTransitions,
+    });
+
+    return {
+      status: "confirm_required",
+      affectedSlots: [...new Set(conflictingTransitions.map((t) => t.slotId))],
+    };
+  }
+
+  const blockedSlotIds =
+    policy === "block"
+      ? new Set(conflictingTransitions.map((transition) => transition.slotId))
+      : new Set<string>();
+
+  const upsertRows: Array<{
+    poll_id: string;
+    slot_id: string;
+    participant_name: string;
+    response: "yes" | "if_need_be" | "no";
+    umpire_id: string;
+    updated_at: string;
+  }> = [];
+
+  const deleteSlotIds: string[] = [];
+
+  for (const [slotId, response] of dedupedResponses) {
+    if (blockedSlotIds.has(slotId)) continue;
+
+    if (response === null) {
+      deleteSlotIds.push(slotId);
+      continue;
+    }
+
+    upsertRows.push({
+      poll_id: pollId,
+      slot_id: slotId,
+      participant_name: participantName,
+      response,
+      umpire_id: umpireId,
+      updated_at: new Date().toISOString(),
+    });
+  }
+
+  if (upsertRows.length > 0) {
+    const { error } = await supabase
+      .from("availability_responses")
+      .upsert(upsertRows, { onConflict: "poll_id,slot_id,umpire_id" });
+
+    if (error) throw new Error(error.message);
+  }
+
+  if (deleteSlotIds.length > 0) {
+    const { error } = await supabase
+      .from("availability_responses")
+      .delete()
+      .eq("poll_id", pollId)
+      .eq("umpire_id", umpireId)
+      .in("slot_id", deleteSlotIds);
+
+    if (error) throw new Error(error.message);
+  }
+
+  if (policy === "block" && conflictingTransitions.length > 0) {
+    await logAvailabilityWarnings({
+      organizationId: poll.organization_id,
+      pollId,
+      umpireId,
+      policy,
+      outcome: "blocked",
+      transitions: conflictingTransitions,
+    });
+
+    return {
+      status: "partial_saved",
+      blockedSlots: Array.from(blockedSlotIds),
+    };
+  }
+
+  return { status: "saved" };
 }

--- a/lib/actions/public-polls.ts
+++ b/lib/actions/public-polls.ts
@@ -4,6 +4,10 @@ import { createClient } from "@/lib/supabase/server";
 import { getTenantId } from "@/lib/tenant";
 import { mapMatchesToSlots } from "@/lib/domain/match-slot-mapping";
 import { createServiceClient } from "@/lib/supabase/service";
+import {
+  AVAILABILITY_GUARD_POLICIES,
+  type AvailabilityGuardPolicy,
+} from "@/lib/types/availability";
 import type {
   Poll,
   PollSlot,
@@ -31,8 +35,6 @@ export type SubmitResponsesResult =
   | { status: "confirm_required"; affectedSlots: string[] }
   | { status: "partial_saved"; blockedSlots: string[] };
 
-export type AvailabilityGuardPolicy = "warn" | "block";
-
 export type AvailabilityGuardStatus = {
   policy: AvailabilityGuardPolicy;
   assignedSlotIds: string[];
@@ -46,32 +48,49 @@ function isDowngradeTransition(
   from: AvailabilityResponse["response"] | null,
   to: ResponseInput["response"],
 ): boolean {
+  // By product decision, "yes" -> "if_need_be" stays allowed.
+  // Guarding only applies when downgrading to explicitly unavailable/none.
   return (
     (from === "yes" || from === "if_need_be") && (to === "no" || to === null)
   );
 }
 
+type ServiceClient = ReturnType<typeof createServiceClient>;
+
+function isAvailabilityGuardPolicy(
+  value: unknown,
+): value is AvailabilityGuardPolicy {
+  return (
+    typeof value === "string" &&
+    AVAILABILITY_GUARD_POLICIES.includes(value as AvailabilityGuardPolicy)
+  );
+}
+
 async function getGuardPolicyForOrganization(
   organizationId: string,
+  serviceClient?: ServiceClient,
 ): Promise<AvailabilityGuardPolicy> {
-  const serviceClient = createServiceClient();
-  const { data, error } = await serviceClient
+  const client = serviceClient ?? createServiceClient();
+  const { data, error } = await client
     .from("organization_settings")
     .select("availability_guard_policy")
     .eq("organization_id", organizationId)
     .maybeSingle();
 
   if (error) throw new Error(error.message);
-  return (data?.availability_guard_policy ?? "warn") as AvailabilityGuardPolicy;
+  return isAvailabilityGuardPolicy(data?.availability_guard_policy)
+    ? data.availability_guard_policy
+    : "warn";
 }
 
 async function getAssignedSlotIds(
   pollId: string,
   umpireId: string,
+  serviceClient?: ServiceClient,
 ): Promise<Set<string>> {
-  const serviceClient = createServiceClient();
+  const client = serviceClient ?? createServiceClient();
 
-  const { data: assignments, error: assignmentError } = await serviceClient
+  const { data: assignments, error: assignmentError } = await client
     .from("assignments")
     .select("match_id")
     .eq("poll_id", pollId)
@@ -84,7 +103,7 @@ async function getAssignedSlotIds(
   );
   if (matchIds.length === 0) return new Set<string>();
 
-  const { data: matches, error: matchError } = await serviceClient
+  const { data: matches, error: matchError } = await client
     .from("matches")
     .select(
       "id, date, start_time, home_team, away_team, competition, venue, field, required_level, created_by, created_at, organization_id",
@@ -93,7 +112,7 @@ async function getAssignedSlotIds(
 
   if (matchError) throw new Error(matchError.message);
 
-  const { data: slots, error: slotError } = await serviceClient
+  const { data: slots, error: slotError } = await client
     .from("poll_slots")
     .select("id, poll_id, start_time, end_time")
     .eq("poll_id", pollId);
@@ -282,6 +301,7 @@ export async function getAvailabilityGuardStatus(
   umpireId: string,
 ): Promise<AvailabilityGuardStatus> {
   const supabase = await createClient();
+  const serviceClient = createServiceClient();
 
   const { data: poll, error } = await supabase
     .from("polls")
@@ -297,8 +317,8 @@ export async function getAvailabilityGuardStatus(
   }
 
   const [policy, assignedSlotIds] = await Promise.all([
-    getGuardPolicyForOrganization(poll.organization_id),
-    getAssignedSlotIds(pollId, umpireId),
+    getGuardPolicyForOrganization(poll.organization_id, serviceClient),
+    getAssignedSlotIds(pollId, umpireId, serviceClient),
   ]);
 
   return {
@@ -319,6 +339,7 @@ export async function submitResponses(
   options?: { confirmAssignedDowngrade?: boolean },
 ): Promise<SubmitResponsesResult> {
   const supabase = await createClient();
+  const serviceClient = createServiceClient();
 
   // Verify poll is open and get organization scope
   const { data: poll, error: pollError } = await supabase
@@ -346,8 +367,8 @@ export async function submitResponses(
       .eq("poll_id", pollId)
       .eq("umpire_id", umpireId)
       .in("slot_id", submittedSlotIds),
-    getGuardPolicyForOrganization(poll.organization_id),
-    getAssignedSlotIds(pollId, umpireId),
+    getGuardPolicyForOrganization(poll.organization_id, serviceClient),
+    getAssignedSlotIds(pollId, umpireId, serviceClient),
   ]);
 
   if (existingResponseRows.error) {

--- a/lib/actions/settings.ts
+++ b/lib/actions/settings.ts
@@ -2,8 +2,10 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { requireTenantId } from "@/lib/tenant";
-
-export type AvailabilityGuardPolicy = "warn" | "block";
+import {
+  AVAILABILITY_GUARD_POLICIES,
+  type AvailabilityGuardPolicy,
+} from "@/lib/types/availability";
 
 async function requireAuth() {
   const supabase = await createClient();
@@ -12,6 +14,15 @@ async function requireAuth() {
   } = await supabase.auth.getUser();
   if (!user) throw new Error("Not authenticated");
   return { supabase, user };
+}
+
+function isAvailabilityGuardPolicy(
+  value: unknown,
+): value is AvailabilityGuardPolicy {
+  return (
+    typeof value === "string" &&
+    AVAILABILITY_GUARD_POLICIES.includes(value as AvailabilityGuardPolicy)
+  );
 }
 
 async function isPlannerInTenant(
@@ -42,7 +53,8 @@ export async function getAvailabilityGuardPolicy(): Promise<AvailabilityGuardPol
     .maybeSingle();
 
   if (error) throw new Error(error.message);
-  return (data?.availability_guard_policy ?? "warn") as AvailabilityGuardPolicy;
+  const policy = data?.availability_guard_policy;
+  return isAvailabilityGuardPolicy(policy) ? policy : "warn";
 }
 
 export async function updateAvailabilityGuardPolicy(
@@ -50,6 +62,9 @@ export async function updateAvailabilityGuardPolicy(
 ): Promise<void> {
   const { supabase, user } = await requireAuth();
   const tenantId = await requireTenantId();
+  if (!isAvailabilityGuardPolicy(policy)) {
+    throw new Error(`Invalid policy value: ${String(policy)}`);
+  }
 
   const canEdit = await isPlannerInTenant(supabase, tenantId, user.id);
   if (!canEdit) throw new Error("Only planners can update this setting");

--- a/lib/actions/settings.ts
+++ b/lib/actions/settings.ts
@@ -1,0 +1,68 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { requireTenantId } from "@/lib/tenant";
+
+export type AvailabilityGuardPolicy = "warn" | "block";
+
+async function requireAuth() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+  return { supabase, user };
+}
+
+async function isPlannerInTenant(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  tenantId: string,
+  userId: string,
+): Promise<boolean> {
+  const { data, error } = await supabase
+    .from("organization_members")
+    .select("id")
+    .eq("organization_id", tenantId)
+    .eq("user_id", userId)
+    .eq("role", "planner")
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return Boolean(data);
+}
+
+export async function getAvailabilityGuardPolicy(): Promise<AvailabilityGuardPolicy> {
+  const { supabase } = await requireAuth();
+  const tenantId = await requireTenantId();
+
+  const { data, error } = await supabase
+    .from("organization_settings")
+    .select("availability_guard_policy")
+    .eq("organization_id", tenantId)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return (data?.availability_guard_policy ?? "warn") as AvailabilityGuardPolicy;
+}
+
+export async function updateAvailabilityGuardPolicy(
+  policy: AvailabilityGuardPolicy,
+): Promise<void> {
+  const { supabase, user } = await requireAuth();
+  const tenantId = await requireTenantId();
+
+  const canEdit = await isPlannerInTenant(supabase, tenantId, user.id);
+  if (!canEdit) throw new Error("Only planners can update this setting");
+
+  const { error } = await supabase.from("organization_settings").upsert(
+    {
+      organization_id: tenantId,
+      availability_guard_policy: policy,
+      updated_at: new Date().toISOString(),
+      updated_by: user.id,
+    },
+    { onConflict: "organization_id" },
+  );
+
+  if (error) throw new Error(error.message);
+}

--- a/lib/types/availability.ts
+++ b/lib/types/availability.ts
@@ -1,0 +1,4 @@
+export const AVAILABILITY_GUARD_POLICIES = ["warn", "block"] as const;
+
+export type AvailabilityGuardPolicy =
+  (typeof AVAILABILITY_GUARD_POLICIES)[number];

--- a/messages/en.json
+++ b/messages/en.json
@@ -89,7 +89,9 @@
     "activityAssignment": "{umpire} assigned to {homeTeam} vs {awayTeam}",
     "activityAssignmentsBatch": "{count, plural, one {# umpire} other {# umpires}} assigned",
     "activityMatchAdded": "Match added: {homeTeam} vs {awayTeam}",
-    "activityMatchesBatch": "{count, plural, one {# match} other {# matches}} added"
+    "activityMatchesBatch": "{count, plural, one {# match} other {# matches}} added",
+    "activityAvailabilityWarned": "Availability warning: {umpire} is changing assigned-slot availability in {pollTitle}",
+    "activityAvailabilityBlocked": "Availability blocked: {umpire} could not set assigned-slot availability to unavailable in {pollTitle}"
   },
   "matches": {
     "pageTitle": "Matches",
@@ -317,7 +319,12 @@
     "couldNotResendCode": "Could not resend code. Please try again later.",
     "useDifferentEmail": "Use a different email",
     "pastDatesToggle": "{count, plural, one {# past date} other {# past dates}}",
-    "allDatesInPast": "All dates in this poll have passed. Your previous responses are shown below."
+    "allDatesInPast": "All dates in this poll have passed. Your previous responses are shown below.",
+    "guardConfirmTitle": "Assigned match warning",
+    "guardConfirmDescription": "You are assigned to at least one match in this slot. Are you sure you want to mark yourself unavailable?",
+    "guardConfirmCancel": "Go back",
+    "guardConfirmProceed": "Mark unavailable",
+    "guardBlockedPartialSaved": "{count, plural, one {# assigned-slot downgrade was blocked. Other changes were saved.} other {# assigned-slot downgrades were blocked. Other changes were saved.}}"
   },
   "umpires": {
     "pageTitle": "Umpires",
@@ -364,7 +371,19 @@
     "levelLabelTop": "Top",
     "addTeam": "Add team",
     "duplicateTeamName": "A team with this name already exists",
-    "teamError": "Something went wrong. Please try again."
+    "teamError": "Something went wrong. Please try again.",
+    "guardPolicySection": "Availability guard",
+    "guardPolicyTitle": "Assigned-slot availability policy",
+    "guardPolicyHelp": "Choose what happens when an umpire tries to downgrade from available or maybe to unavailable/none in a slot where they are assigned.",
+    "guardPolicyWarnLabel": "Warn with confirmation",
+    "guardPolicyWarnHelp": "Umpires can still save the change, but must explicitly confirm first.",
+    "guardPolicyBlockLabel": "Hard block",
+    "guardPolicyBlockHelp": "Downgrading to unavailable/none is blocked for assigned slots. Other changes can still be saved.",
+    "guardPolicySave": "Save policy",
+    "guardPolicySaving": "Saving...",
+    "guardPolicySaved": "Saved",
+    "guardPolicyReadOnly": "Only planners can edit this setting.",
+    "guardPolicyError": "Could not save this setting. Please try again."
   },
   "landing": {
     "title": "Fluitplanner",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -89,7 +89,9 @@
     "activityAssignment": "{umpire} ingedeeld bij {homeTeam} vs {awayTeam}",
     "activityAssignmentsBatch": "{count, plural, one {# scheidsrechter} other {# scheidsrechters}} ingedeeld",
     "activityMatchAdded": "Wedstrijd toegevoegd: {homeTeam} vs {awayTeam}",
-    "activityMatchesBatch": "{count, plural, one {# wedstrijd} other {# wedstrijden}} toegevoegd"
+    "activityMatchesBatch": "{count, plural, one {# wedstrijd} other {# wedstrijden}} toegevoegd",
+    "activityAvailabilityWarned": "Beschikbaarheidswaarschuwing: {umpire} wijzigt beschikbaarheid in een toegewezen slot in {pollTitle}",
+    "activityAvailabilityBlocked": "Beschikbaarheid geblokkeerd: {umpire} kon in {pollTitle} niet op niet-beschikbaar zetten voor een toegewezen slot"
   },
   "matches": {
     "pageTitle": "Wedstrijden",
@@ -317,7 +319,12 @@
     "couldNotResendCode": "Code opnieuw versturen mislukt. Probeer het later opnieuw.",
     "useDifferentEmail": "Ander e-mailadres gebruiken",
     "pastDatesToggle": "{count, plural, one {# afgelopen datum} other {# afgelopen datums}}",
-    "allDatesInPast": "Alle datums in deze peiling zijn verstreken. Je eerdere reacties staan hieronder."
+    "allDatesInPast": "Alle datums in deze peiling zijn verstreken. Je eerdere reacties staan hieronder.",
+    "guardConfirmTitle": "Waarschuwing toegewezen wedstrijd",
+    "guardConfirmDescription": "Je bent ingedeeld voor minimaal één wedstrijd in dit slot. Weet je zeker dat je jezelf als niet beschikbaar wilt markeren?",
+    "guardConfirmCancel": "Terug",
+    "guardConfirmProceed": "Niet beschikbaar markeren",
+    "guardBlockedPartialSaved": "{count, plural, one {# wijziging naar niet-beschikbaar in een toegewezen slot is geblokkeerd. Overige wijzigingen zijn opgeslagen.} other {# wijzigingen naar niet-beschikbaar in toegewezen slots zijn geblokkeerd. Overige wijzigingen zijn opgeslagen.}}"
   },
   "umpires": {
     "pageTitle": "Scheidsrechters",
@@ -364,7 +371,19 @@
     "levelLabelTop": "Top",
     "addTeam": "Team toevoegen",
     "duplicateTeamName": "Er bestaat al een team met deze naam",
-    "teamError": "Er is iets misgegaan. Probeer het opnieuw."
+    "teamError": "Er is iets misgegaan. Probeer het opnieuw.",
+    "guardPolicySection": "Beschikbaarheidsbeveiliging",
+    "guardPolicyTitle": "Beleid voor toegewezen slots",
+    "guardPolicyHelp": "Kies wat er gebeurt wanneer een scheidsrechter van beschikbaar/indien nodig naar niet beschikbaar/geen reactie wil gaan in een slot waar die is ingedeeld.",
+    "guardPolicyWarnLabel": "Waarschuwen met bevestiging",
+    "guardPolicyWarnHelp": "Scheidsrechters kunnen de wijziging nog steeds opslaan, maar moeten eerst expliciet bevestigen.",
+    "guardPolicyBlockLabel": "Hard blokkeren",
+    "guardPolicyBlockHelp": "Wijzigen naar niet beschikbaar/geen reactie is geblokkeerd voor toegewezen slots. Overige wijzigingen kunnen wel worden opgeslagen.",
+    "guardPolicySave": "Beleid opslaan",
+    "guardPolicySaving": "Opslaan...",
+    "guardPolicySaved": "Opgeslagen",
+    "guardPolicyReadOnly": "Alleen planners kunnen deze instelling wijzigen.",
+    "guardPolicyError": "Deze instelling opslaan is mislukt. Probeer het opnieuw."
   },
   "landing": {
     "title": "Fluitplanner",

--- a/supabase/migrations/20260224000001_availability_guard_settings_and_warnings.sql
+++ b/supabase/migrations/20260224000001_availability_guard_settings_and_warnings.sql
@@ -12,6 +12,26 @@ select id
 from public.organizations
 on conflict (organization_id) do nothing;
 
+create or replace function public.fn_create_organization_settings_if_missing()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.organization_settings (organization_id)
+  values (new.id)
+  on conflict (organization_id) do nothing;
+
+  return new;
+end;
+$$;
+
+create trigger trg_create_organization_settings_after_org_insert
+after insert on public.organizations
+for each row
+execute function public.fn_create_organization_settings_if_missing();
+
 create table public.availability_change_warnings (
   id uuid primary key default gen_random_uuid(),
   organization_id uuid not null references public.organizations on delete cascade,

--- a/supabase/migrations/20260224000001_availability_guard_settings_and_warnings.sql
+++ b/supabase/migrations/20260224000001_availability_guard_settings_and_warnings.sql
@@ -1,0 +1,71 @@
+-- Organization-level availability guard policy and warning events
+
+create table public.organization_settings (
+  organization_id uuid primary key references public.organizations on delete cascade,
+  availability_guard_policy text not null default 'warn' check (availability_guard_policy in ('warn', 'block')),
+  updated_at timestamptz not null default now(),
+  updated_by uuid references auth.users
+);
+
+insert into public.organization_settings (organization_id)
+select id
+from public.organizations
+on conflict (organization_id) do nothing;
+
+create table public.availability_change_warnings (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations on delete cascade,
+  poll_id uuid not null references public.polls on delete cascade,
+  slot_id uuid not null references public.poll_slots on delete cascade,
+  umpire_id uuid not null references public.umpires on delete cascade,
+  from_response text not null check (from_response in ('yes', 'if_need_be')),
+  to_response text not null check (to_response in ('no', 'none')),
+  policy text not null check (policy in ('warn', 'block')),
+  outcome text not null check (outcome in ('confirm_required', 'blocked')),
+  created_at timestamptz not null default now()
+);
+
+create index idx_availability_change_warnings_org_created
+  on public.availability_change_warnings (organization_id, created_at desc);
+
+create index idx_availability_change_warnings_poll_umpire_created
+  on public.availability_change_warnings (poll_id, umpire_id, created_at desc);
+
+alter table public.organization_settings enable row level security;
+alter table public.availability_change_warnings enable row level security;
+
+create policy "Tenant isolation for organization_settings select"
+  on public.organization_settings for select to authenticated
+  using (
+    organization_id in (
+      select organization_id from public.organization_members where user_id = auth.uid()
+    )
+  );
+
+create policy "Planner can update organization_settings"
+  on public.organization_settings for update to authenticated
+  using (
+    organization_id in (
+      select organization_id
+      from public.organization_members
+      where user_id = auth.uid() and role = 'planner'
+    )
+  );
+
+create policy "Planner can insert organization_settings"
+  on public.organization_settings for insert to authenticated
+  with check (
+    organization_id in (
+      select organization_id
+      from public.organization_members
+      where user_id = auth.uid() and role = 'planner'
+    )
+  );
+
+create policy "Tenant isolation for availability_change_warnings select"
+  on public.availability_change_warnings for select to authenticated
+  using (
+    organization_id in (
+      select organization_id from public.organization_members where user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
Summary
- implement availability downgrade guard setting with warn/block modes
- extend poll submission API, settings actions, and dashboard activity for warning logging
- add warning UI/strings and dashboard highlight plus migrations for settings and warnings

Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added availability guard settings page allowing admins to configure organization-wide policies ("warn" or "block") for managing assigned slot availability changes.
  * Introduced confirmation dialogs when attempting to downgrade availability on assigned slots, with the ability to proceed or cancel based on policy setting.
  * Display of availability warnings in the dashboard activity feed with visual indicators.

* **Tests**
  * Extended test coverage for availability guard functionality and warning events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->