### PR TITLE
Add availability lock mode to prevent umpire assignment conflicts

### DIFF
--- a/__tests__/lib/actions/public-polls.test.ts
+++ b/__tests__/lib/actions/public-polls.test.ts
@@ -37,6 +37,19 @@ vi.mock("@/lib/supabase/server", () => ({
   })),
 }));
 
+const mockServiceFrom = vi.fn(() => ({
+  select: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  in: vi.fn().mockReturnThis(),
+  single: vi.fn().mockResolvedValue({ data: null, error: null }),
+}));
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: vi.fn(() => ({
+    from: mockServiceFrom,
+  })),
+}));
+
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                            */
 /* ------------------------------------------------------------------ */

--- a/__tests__/lib/actions/public-polls.test.ts
+++ b/__tests__/lib/actions/public-polls.test.ts
@@ -42,6 +42,8 @@ const mockServiceFrom = vi.fn(() => ({
   eq: vi.fn().mockReturnThis(),
   in: vi.fn().mockReturnThis(),
   single: vi.fn().mockResolvedValue({ data: null, error: null }),
+  insert: vi.fn().mockResolvedValue({ error: null }),
+  maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
 }));
 
 vi.mock("@/lib/supabase/service", () => ({

--- a/app/protected/settings/page.tsx
+++ b/app/protected/settings/page.tsx
@@ -1,12 +1,21 @@
 import { Suspense } from "react";
 import { TableSkeleton } from "@/components/skeletons";
 import { getManagedTeams } from "@/lib/actions/managed-teams";
+import { getOrganizationSettings } from "@/lib/actions/organization-settings";
 import { ManagedTeamsList } from "@/components/settings/managed-teams-list";
+import { AvailabilityLockSetting } from "@/components/settings/availability-lock-setting";
 import { getTranslations } from "next-intl/server";
 
 async function ManagedTeamsLoader() {
   const teams = await getManagedTeams();
   return <ManagedTeamsList initialTeams={teams} />;
+}
+
+async function AvailabilityLockLoader() {
+  const settings = await getOrganizationSettings();
+  return (
+    <AvailabilityLockSetting initialMode={settings.availability_lock_mode} />
+  );
 }
 
 export default async function SettingsPage() {
@@ -21,6 +30,16 @@ export default async function SettingsPage() {
         <h2 className="mb-4 text-lg font-semibold">{t("managedTeams")}</h2>
         <Suspense fallback={<TableSkeleton rows={3} cols={3} />}>
           <ManagedTeamsLoader />
+        </Suspense>
+      </div>
+      <div>
+        <h2 className="mb-4 text-lg font-semibold">
+          {t("availabilityLockTitle")}
+        </h2>
+        <Suspense
+          fallback={<div className="bg-muted h-24 animate-pulse rounded-md" />}
+        >
+          <AvailabilityLockLoader />
         </Suspense>
       </div>
     </div>

--- a/components/__tests__/poll-response-page-integration.test.tsx
+++ b/components/__tests__/poll-response-page-integration.test.tsx
@@ -16,6 +16,13 @@ vi.mock("@/lib/actions/verification", () => ({
   requestVerification: vi.fn(),
 }));
 
+vi.mock("@/lib/actions/public-poll-assignments", () => ({
+  getPollAssignmentContext: vi.fn().mockResolvedValue({
+    lockMode: "warn",
+    assignedSlots: [],
+  }),
+}));
+
 vi.mock("@/lib/supabase/client", () => ({
   createClient: () => ({
     auth: {

--- a/components/dashboard/recent-activity-section.tsx
+++ b/components/dashboard/recent-activity-section.tsx
@@ -2,6 +2,7 @@ import { getRecentActivity, type ActivityEvent } from "@/lib/actions/dashboard";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatDistanceToNow } from "date-fns";
 import { nl } from "date-fns/locale";
+import { AlertTriangle } from "lucide-react";
 import { getTranslations, getLocale } from "next-intl/server";
 
 function formatEvent(
@@ -29,7 +30,17 @@ function formatEvent(
       });
     case "matches_batch":
       return t("activityMatchesBatch", { count: event.count });
+    case "availability_override":
+      return t("activityAvailabilityOverride", {
+        umpire: event.umpire,
+        homeTeam: event.homeTeam,
+        awayTeam: event.awayTeam,
+      });
   }
+}
+
+function isOverrideEvent(event: ActivityEvent): boolean {
+  return event.type === "availability_override";
 }
 
 export async function RecentActivitySection() {
@@ -50,8 +61,16 @@ export async function RecentActivitySection() {
         ) : (
           <ul className="flex flex-col gap-3">
             {events.map((event, i) => (
-              <li key={i} className="flex items-center justify-between text-sm">
-                <span>{formatEvent(event, t)}</span>
+              <li
+                key={i}
+                className={`flex items-center justify-between text-sm ${isOverrideEvent(event) ? "text-orange-600 dark:text-orange-400 font-medium" : ""}`}
+              >
+                <span className="flex items-center gap-1.5">
+                  {isOverrideEvent(event) && (
+                    <AlertTriangle className="h-4 w-4 shrink-0" />
+                  )}
+                  {formatEvent(event, t)}
+                </span>
                 <span className="text-muted-foreground text-xs whitespace-nowrap ml-4">
                   {formatDistanceToNow(new Date(event.timestamp), {
                     addSuffix: true,

--- a/components/poll-response/assignment-warning-dialog.tsx
+++ b/components/poll-response/assignment-warning-dialog.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { AlertTriangle } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  affectedMatches: { homeTeam: string; awayTeam: string }[];
+  onConfirm: () => void;
+};
+
+export function AssignmentWarningDialog({
+  open,
+  onOpenChange,
+  affectedMatches,
+  onConfirm,
+}: Props) {
+  const t = useTranslations("pollResponse");
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-orange-500" />
+            {t("warningDialogTitle")}
+          </AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-2">
+              <p>{t("warningDialogDescription")}</p>
+              <ul className="list-disc space-y-1 pl-5">
+                {affectedMatches.map((match, i) => (
+                  <li key={i}>
+                    {match.homeTeam} vs {match.awayTeam}
+                  </li>
+                ))}
+              </ul>
+              <p className="font-medium">{t("warningDialogNotice")}</p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{t("warningDialogCancel")}</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" onClick={onConfirm}>
+            {t("warningDialogProceed")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/components/poll-response/availability-form.tsx
+++ b/components/poll-response/availability-form.tsx
@@ -4,9 +4,11 @@ import { useState, useRef, useEffect, useMemo } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { SlotRow } from "@/components/poll-response/slot-row";
 import { StickyDirtyBar } from "@/components/poll-response/sticky-dirty-bar";
+import { AssignmentWarningDialog } from "@/components/poll-response/assignment-warning-dialog";
 import { submitResponses } from "@/lib/actions/public-polls";
 import { useTranslations, useFormatter } from "next-intl";
 import type { PollSlot, AvailabilityResponse } from "@/lib/types/domain";
+import type { PollAssignmentContext } from "@/lib/actions/public-poll-assignments";
 
 type ResponseValue = "yes" | "if_need_be" | "no";
 
@@ -16,6 +18,7 @@ type Props = {
   umpireName: string;
   slots: PollSlot[];
   existingResponses: AvailabilityResponse[];
+  assignmentContext?: PollAssignmentContext | null;
 };
 
 export function AvailabilityForm({
@@ -24,6 +27,7 @@ export function AvailabilityForm({
   umpireName,
   slots,
   existingResponses,
+  assignmentContext,
 }: Props) {
   const t = useTranslations("pollResponse");
   const format = useFormatter();
@@ -91,10 +95,52 @@ export function AvailabilityForm({
   const [showSavedInBar, setShowSavedInBar] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showPastDates, setShowPastDates] = useState(false);
+  const [showOverrideDialog, setShowOverrideDialog] = useState(false);
 
   const [savedBaseline, setSavedBaseline] =
     useState<Record<string, ResponseValue | null>>(initialState);
   const savedTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Assignment context derived state
+  const lockMode = assignmentContext?.lockMode ?? "warn";
+  const assignedSlotMap = useMemo(() => {
+    const map = new Map<
+      string,
+      { matchId: string; homeTeam: string; awayTeam: string }[]
+    >();
+    if (!assignmentContext) return map;
+    for (const slot of assignmentContext.assignedSlots) {
+      map.set(slot.slotId, slot.matches);
+    }
+    return map;
+  }, [assignmentContext]);
+
+  // Track which assigned slots are being downgraded (for warnings)
+  const pendingOverrideSlots = useMemo(() => {
+    const overrides = new Set<string>();
+    for (const slotId of assignedSlotMap.keys()) {
+      const saved = savedBaseline[slotId];
+      const current = responses[slotId];
+      const wasAvailable = saved === "yes" || saved === "if_need_be";
+      const isNowNo = current === "no";
+      if (wasAvailable && isNowNo) {
+        overrides.add(slotId);
+      }
+    }
+    return overrides;
+  }, [responses, savedBaseline, assignedSlotMap]);
+
+  // Collect all matches affected by pending overrides (for dialog)
+  const affectedMatches = useMemo(() => {
+    const matches: { homeTeam: string; awayTeam: string }[] = [];
+    for (const slotId of pendingOverrideSlots) {
+      const slotMatches = assignedSlotMap.get(slotId);
+      if (slotMatches) {
+        matches.push(...slotMatches);
+      }
+    }
+    return matches;
+  }, [pendingOverrideSlots, assignedSlotMap]);
 
   // Only track dirty state for future (editable) slots
   const isDirty = useMemo(() => {
@@ -122,6 +168,10 @@ export function AvailabilityForm({
   }, []);
 
   function handleChange(slotId: string, value: ResponseValue | null) {
+    // In lock mode, prevent any changes to assigned slots
+    if (lockMode === "lock" && assignedSlotMap.has(slotId)) {
+      return;
+    }
     setResponses((prev) => ({ ...prev, [slotId]: value }));
     setError(null);
   }
@@ -133,8 +183,20 @@ export function AvailabilityForm({
 
   async function handleSubmit(e?: React.FormEvent) {
     if (e) e.preventDefault();
+
+    // In warn mode, show confirmation dialog if there are pending overrides
+    if (
+      lockMode === "warn" &&
+      pendingOverrideSlots.size > 0 &&
+      !showOverrideDialog
+    ) {
+      setShowOverrideDialog(true);
+      return;
+    }
+
     setSaving(true);
     setError(null);
+    setShowOverrideDialog(false);
     // Only submit responses for future slots
     const toSubmit = Object.entries(responses)
       .filter(([slotId, value]) => value !== null && futureSlotIds.has(slotId))
@@ -146,10 +208,18 @@ export function AvailabilityForm({
       if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
       savedTimerRef.current = setTimeout(() => setShowSavedInBar(false), 2000);
     } catch (err) {
-      setError(err instanceof Error ? err.message : t("failedToSave"));
+      if (err instanceof Error && err.message === "AVAILABILITY_LOCKED") {
+        setError(t("availabilityLockedError"));
+      } else {
+        setError(err instanceof Error ? err.message : t("failedToSave"));
+      }
     } finally {
       setSaving(false);
     }
+  }
+
+  function handleOverrideConfirm() {
+    handleSubmit();
   }
 
   const barVisible = isDirty || saving || showSavedInBar || error !== null;
@@ -165,16 +235,30 @@ export function AvailabilityForm({
           {group.label}
         </div>
         <div className="px-3">
-          {group.slots.map((slot) => (
-            <SlotRow
-              key={slot.id}
-              startTime={slot.start_time}
-              endTime={slot.end_time}
-              value={responses[slot.id]}
-              onChange={(value) => handleChange(slot.id, value)}
-              disabled={disabled}
-            />
-          ))}
+          {group.slots.map((slot) => {
+            const isAssigned = assignedSlotMap.has(slot.id);
+            const isLocked = lockMode === "lock" && isAssigned;
+            const isOverriding =
+              lockMode === "warn" && pendingOverrideSlots.has(slot.id);
+            const slotMatches = assignedSlotMap.get(slot.id);
+            const matchLabels = slotMatches?.map(
+              (m) => `${m.homeTeam} vs ${m.awayTeam}`,
+            );
+
+            return (
+              <SlotRow
+                key={slot.id}
+                startTime={slot.start_time}
+                endTime={slot.end_time}
+                value={responses[slot.id]}
+                onChange={(value) => handleChange(slot.id, value)}
+                disabled={disabled}
+                locked={isLocked}
+                showWarning={isOverriding}
+                assignedMatchLabels={matchLabels}
+              />
+            );
+          })}
         </div>
       </div>
     );
@@ -237,6 +321,14 @@ export function AvailabilityForm({
           />
         </>
       )}
+
+      {/* Override warning dialog (warn mode only) */}
+      <AssignmentWarningDialog
+        open={showOverrideDialog}
+        onOpenChange={setShowOverrideDialog}
+        affectedMatches={affectedMatches}
+        onConfirm={handleOverrideConfirm}
+      />
     </form>
   );
 }

--- a/components/poll-response/poll-response-page.tsx
+++ b/components/poll-response/poll-response-page.tsx
@@ -7,6 +7,10 @@ import { UmpireIdentifier } from "@/components/poll-response/umpire-identifier";
 import { VerificationForm } from "@/components/poll-response/verification-form";
 import { createClient } from "@/lib/supabase/client";
 import { findUmpireById, getMyResponses } from "@/lib/actions/public-polls";
+import {
+  getPollAssignmentContext,
+  type PollAssignmentContext,
+} from "@/lib/actions/public-poll-assignments";
 import { verifyMagicLink } from "@/lib/actions/verification";
 import { LayoutDashboard } from "lucide-react";
 import Link from "next/link";
@@ -70,6 +74,8 @@ export function PollResponsePage({
     email: string;
     maskedEmail: string;
   } | null>(null);
+  const [assignmentContext, setAssignmentContext] =
+    useState<PollAssignmentContext | null>(null);
 
   useEffect(() => {
     async function init() {
@@ -109,6 +115,15 @@ export function PollResponsePage({
     }
     init();
   }, [poll.id, verifyToken]);
+
+  // Fetch assignment context whenever umpire changes
+  useEffect(() => {
+    if (umpire) {
+      getPollAssignmentContext(poll.id, umpire.id).then(setAssignmentContext);
+    } else {
+      setAssignmentContext(null);
+    }
+  }, [umpire, poll.id]);
 
   async function handleIdentified(identified: Umpire) {
     setCookie(COOKIE_NAME, identified.id, 365);
@@ -233,6 +248,7 @@ export function PollResponsePage({
         umpireName={umpire.name}
         slots={slots}
         existingResponses={existingResponses}
+        assignmentContext={assignmentContext}
       />
     </div>
   );

--- a/components/poll-response/poll-response-page.tsx
+++ b/components/poll-response/poll-response-page.tsx
@@ -120,9 +120,14 @@ export function PollResponsePage({
   useEffect(() => {
     let cancelled = false;
     if (umpire) {
-      getPollAssignmentContext(poll.id, umpire.id).then((ctx) => {
-        if (!cancelled) setAssignmentContext(ctx);
-      });
+      getPollAssignmentContext(poll.id, umpire.id)
+        .then((ctx) => {
+          if (!cancelled) setAssignmentContext(ctx);
+        })
+        .catch(() => {
+          // Gracefully degrade: no lock/warn enforcement on fetch failure
+          if (!cancelled) setAssignmentContext(null);
+        });
     } else {
       setAssignmentContext(null);
     }

--- a/components/poll-response/poll-response-page.tsx
+++ b/components/poll-response/poll-response-page.tsx
@@ -118,11 +118,17 @@ export function PollResponsePage({
 
   // Fetch assignment context whenever umpire changes
   useEffect(() => {
+    let cancelled = false;
     if (umpire) {
-      getPollAssignmentContext(poll.id, umpire.id).then(setAssignmentContext);
+      getPollAssignmentContext(poll.id, umpire.id).then((ctx) => {
+        if (!cancelled) setAssignmentContext(ctx);
+      });
     } else {
       setAssignmentContext(null);
     }
+    return () => {
+      cancelled = true;
+    };
   }, [umpire, poll.id]);
 
   async function handleIdentified(identified: Umpire) {

--- a/components/poll-response/slot-row.tsx
+++ b/components/poll-response/slot-row.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { Lock, AlertTriangle } from "lucide-react";
 import { useTranslations, useFormatter } from "next-intl";
 
 type ResponseValue = "yes" | "if_need_be" | "no";
@@ -12,6 +13,12 @@ type Props = {
   value: ResponseValue | null;
   onChange: (value: ResponseValue | null) => void;
   disabled?: boolean;
+  /** Lock mode: entire row is locked (grayed out, all buttons disabled) */
+  locked?: boolean;
+  /** Warn mode: umpire has changed to "no" on this assigned slot */
+  showWarning?: boolean;
+  /** Match descriptions for warning display */
+  assignedMatchLabels?: string[];
 };
 
 type ButtonConfig = {
@@ -45,6 +52,9 @@ export function SlotRow({
   value,
   onChange,
   disabled,
+  locked,
+  showWarning,
+  assignedMatchLabels,
 }: Props) {
   const t = useTranslations("pollResponse");
   const format = useFormatter();
@@ -57,31 +67,57 @@ export function SlotRow({
     });
   }
 
+  const isFullyDisabled = disabled || locked;
+
   return (
-    <div
-      className={cn(
-        "flex items-center justify-between border-b py-3 last:border-b-0",
-        disabled && "opacity-60",
+    <div className="last:border-b-0">
+      <div
+        className={cn(
+          "flex items-center justify-between border-b py-3",
+          isFullyDisabled && "opacity-50",
+          locked && "bg-muted/50 rounded-md px-2",
+        )}
+      >
+        <div className="flex flex-col gap-0.5">
+          <div className="text-sm">
+            {formatTime(startTime)} &ndash; {formatTime(endTime)}
+          </div>
+          {locked && (
+            <div className="text-muted-foreground flex items-center gap-1 text-xs">
+              <Lock className="h-3 w-3" />
+              {t("slotLockedAssigned")}
+            </div>
+          )}
+        </div>
+        <div className="flex gap-1.5">
+          {BUTTONS.map((btn) => (
+            <Button
+              key={btn.value}
+              type="button"
+              variant={value === btn.value ? "default" : "outline"}
+              size="sm"
+              className={value === btn.value ? btn.activeClass : ""}
+              onClick={() => onChange(value === btn.value ? null : btn.value)}
+              disabled={isFullyDisabled}
+            >
+              {t(btn.labelKey)}
+            </Button>
+          ))}
+        </div>
+      </div>
+      {showWarning && assignedMatchLabels && assignedMatchLabels.length > 0 && (
+        <div className="flex items-start gap-1.5 px-1 py-1.5 text-xs text-orange-600 dark:text-orange-400">
+          <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+          <span>
+            {assignedMatchLabels.map((label, i) => (
+              <span key={i}>
+                {i > 0 && ", "}
+                {t("assignedToMatch", { match: label })}
+              </span>
+            ))}
+          </span>
+        </div>
       )}
-    >
-      <div className="text-sm">
-        {formatTime(startTime)} &ndash; {formatTime(endTime)}
-      </div>
-      <div className="flex gap-1.5">
-        {BUTTONS.map((btn) => (
-          <Button
-            key={btn.value}
-            type="button"
-            variant={value === btn.value ? "default" : "outline"}
-            size="sm"
-            className={value === btn.value ? btn.activeClass : ""}
-            onClick={() => onChange(value === btn.value ? null : btn.value)}
-            disabled={disabled}
-          >
-            {t(btn.labelKey)}
-          </Button>
-        ))}
-      </div>
     </div>
   );
 }

--- a/components/settings/availability-lock-setting.tsx
+++ b/components/settings/availability-lock-setting.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Label } from "@/components/ui/label";
+import { Lock, AlertTriangle } from "lucide-react";
+import { updateAvailabilityLockMode } from "@/lib/actions/organization-settings";
+import type { AvailabilityLockMode } from "@/lib/types/domain";
+
+type Props = {
+  initialMode: AvailabilityLockMode;
+};
+
+export function AvailabilityLockSetting({ initialMode }: Props) {
+  const t = useTranslations("settings");
+  const [mode, setMode] = useState<AvailabilityLockMode>(initialMode);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleChange(value: string) {
+    const newMode = value as AvailabilityLockMode;
+    setSaving(true);
+    setError(null);
+    try {
+      await updateAvailabilityLockMode(newMode);
+      setMode(newMode);
+    } catch {
+      setError(t("settingError"));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-muted-foreground text-sm">
+        {t("availabilityLockDescription")}
+      </p>
+      <RadioGroup
+        value={mode}
+        onValueChange={handleChange}
+        disabled={saving}
+        className="space-y-2"
+      >
+        <div className="flex items-start gap-3">
+          <RadioGroupItem value="warn" id="lock-mode-warn" className="mt-1" />
+          <Label
+            htmlFor="lock-mode-warn"
+            className="cursor-pointer space-y-0.5"
+          >
+            <div className="flex items-center gap-1.5 font-medium">
+              <AlertTriangle className="h-4 w-4 text-orange-500" />
+              {t("lockModeWarn")}
+            </div>
+            <p className="text-muted-foreground text-sm font-normal">
+              {t("lockModeWarnDescription")}
+            </p>
+          </Label>
+        </div>
+        <div className="flex items-start gap-3">
+          <RadioGroupItem value="lock" id="lock-mode-lock" className="mt-1" />
+          <Label
+            htmlFor="lock-mode-lock"
+            className="cursor-pointer space-y-0.5"
+          >
+            <div className="flex items-center gap-1.5 font-medium">
+              <Lock className="h-4 w-4" />
+              {t("lockModeLock")}
+            </div>
+            <p className="text-muted-foreground text-sm font-normal">
+              {t("lockModeLockDescription")}
+            </p>
+          </Label>
+        </div>
+      </RadioGroup>
+      {error && <p className="text-destructive text-sm">{error}</p>}
+    </div>
+  );
+}

--- a/lib/actions/dashboard.ts
+++ b/lib/actions/dashboard.ts
@@ -329,6 +329,7 @@ export async function getActionItems(): Promise<ActionItem[]> {
     .from("availability_override_logs")
     .select("umpire_id, poll_id, umpires(name), polls(title)")
     .eq("organization_id", tenantId)
+    .not("poll_id", "is", null)
     .gte("created_at", sevenDaysAgo)
     .order("created_at", { ascending: false })
     .limit(50);
@@ -522,7 +523,7 @@ export async function getRecentActivity(): Promise<ActivityEvent[]> {
   const { data: overrideLogs, error: overrideLogError } = await supabase
     .from("availability_override_logs")
     .select(
-      "created_at, poll_id, umpires(name), matches(home_team, away_team), polls(title, organization_id)",
+      "created_at, poll_id, umpires(name), matches(home_team, away_team), polls(title)",
     )
     .eq("organization_id", tenantId)
     .not("poll_id", "is", null)

--- a/lib/actions/dashboard.ts
+++ b/lib/actions/dashboard.ts
@@ -340,6 +340,7 @@ export async function getActionItems(): Promise<ActionItem[]> {
       { umpireNames: Set<string>; pollTitle: string; pollId: string }
     >();
     for (const o of overrides) {
+      if (!o.poll_id) continue; // skip orphaned logs where poll was deleted
       const umpire = Array.isArray(o.umpires) ? o.umpires[0] : o.umpires;
       const poll = Array.isArray(o.polls) ? o.polls[0] : o.polls;
       if (!overrideByPoll.has(o.poll_id)) {
@@ -519,9 +520,10 @@ export async function getRecentActivity(): Promise<ActivityEvent[]> {
   const { data: overrideLogs, error: overrideLogError } = await supabase
     .from("availability_override_logs")
     .select(
-      "created_at, poll_id, umpires(name), matches(home_team, away_team), polls!inner(title, organization_id)",
+      "created_at, poll_id, umpires(name), matches(home_team, away_team), polls(title, organization_id)",
     )
-    .eq("polls.organization_id", tenantId)
+    .eq("organization_id", tenantId)
+    .not("poll_id", "is", null)
     .order("created_at", { ascending: false })
     .limit(50);
 

--- a/lib/actions/dashboard.ts
+++ b/lib/actions/dashboard.ts
@@ -2,7 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { requireTenantId } from "@/lib/tenant";
-import { format, addDays } from "date-fns";
+import { format, addDays, subDays } from "date-fns";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -16,7 +16,11 @@ export type DashboardStats = {
 };
 
 export type ActionItem = {
-  type: "unassigned_match" | "low_response_poll" | "unpolled_match";
+  type:
+    | "unassigned_match"
+    | "low_response_poll"
+    | "unpolled_match"
+    | "availability_override";
   label: string;
   href: string;
 };
@@ -49,6 +53,14 @@ export type ActivityEvent =
   | {
       type: "matches_batch";
       count: number;
+      timestamp: string;
+    }
+  | {
+      type: "availability_override";
+      umpire: string;
+      homeTeam: string;
+      awayTeam: string;
+      pollTitle: string;
       timestamp: string;
     };
 
@@ -311,6 +323,45 @@ export async function getActionItems(): Promise<ActionItem[]> {
     }
   }
 
+  // 6. Availability override alerts (umpires who changed availability despite being assigned)
+  const sevenDaysAgo = subDays(new Date(), 7).toISOString();
+  const { data: overrides, error: overrideError } = await supabase
+    .from("availability_override_logs")
+    .select("umpire_id, poll_id, umpires(name), polls(title)")
+    .eq("organization_id", tenantId)
+    .gte("created_at", sevenDaysAgo)
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (!overrideError && overrides && overrides.length > 0) {
+    // Group by umpire + poll for a cleaner display
+    const overrideByPoll = new Map<
+      string,
+      { umpireNames: Set<string>; pollTitle: string; pollId: string }
+    >();
+    for (const o of overrides) {
+      const umpire = Array.isArray(o.umpires) ? o.umpires[0] : o.umpires;
+      const poll = Array.isArray(o.polls) ? o.polls[0] : o.polls;
+      if (!overrideByPoll.has(o.poll_id)) {
+        overrideByPoll.set(o.poll_id, {
+          umpireNames: new Set(),
+          pollTitle: poll?.title ?? "poll",
+          pollId: o.poll_id,
+        });
+      }
+      overrideByPoll.get(o.poll_id)!.umpireNames.add(umpire?.name ?? "Umpire");
+    }
+
+    for (const [, info] of overrideByPoll) {
+      const count = info.umpireNames.size;
+      items.push({
+        type: "availability_override",
+        label: `${count} umpire${count > 1 ? "s" : ""} withdrew availability despite assignment in ${info.pollTitle}`,
+        href: `/protected/polls/${info.pollId}?tab=assignments`,
+      });
+    }
+  }
+
   return items;
 }
 
@@ -464,8 +515,39 @@ export async function getRecentActivity(): Promise<ActivityEvent[]> {
     };
   });
 
+  // 4. Recent availability override logs
+  const { data: overrideLogs, error: overrideLogError } = await supabase
+    .from("availability_override_logs")
+    .select(
+      "created_at, poll_id, umpires(name), matches(home_team, away_team), polls!inner(title, organization_id)",
+    )
+    .eq("polls.organization_id", tenantId)
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (overrideLogError) throw new Error(overrideLogError.message);
+
+  const overrideEvents: ActivityEvent[] = (overrideLogs ?? []).map((o) => {
+    const umpire = Array.isArray(o.umpires) ? o.umpires[0] : o.umpires;
+    const match = Array.isArray(o.matches) ? o.matches[0] : o.matches;
+    const poll = Array.isArray(o.polls) ? o.polls[0] : o.polls;
+    return {
+      type: "availability_override" as const,
+      umpire: umpire?.name ?? "Umpire",
+      homeTeam: match?.home_team ?? "?",
+      awayTeam: match?.away_team ?? "?",
+      pollTitle: poll?.title ?? "poll",
+      timestamp: o.created_at,
+    };
+  });
+
   // Merge, sort descending, limit 10
-  const allEvents = [...responseEvents, ...assignmentEvents, ...matchEvents];
+  const allEvents = [
+    ...responseEvents,
+    ...assignmentEvents,
+    ...matchEvents,
+    ...overrideEvents,
+  ];
   allEvents.sort(
     (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
   );

--- a/lib/actions/dashboard.ts
+++ b/lib/actions/dashboard.ts
@@ -333,7 +333,9 @@ export async function getActionItems(): Promise<ActionItem[]> {
     .order("created_at", { ascending: false })
     .limit(50);
 
-  if (!overrideError && overrides && overrides.length > 0) {
+  if (overrideError) throw new Error(overrideError.message);
+
+  if (overrides && overrides.length > 0) {
     // Group by umpire + poll for a cleaner display
     const overrideByPoll = new Map<
       string,

--- a/lib/actions/organization-settings.ts
+++ b/lib/actions/organization-settings.ts
@@ -1,0 +1,61 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { requireTenantId } from "@/lib/tenant";
+import type {
+  OrganizationSettings,
+  AvailabilityLockMode,
+} from "@/lib/types/domain";
+
+async function requireAuth() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+  return { supabase, user };
+}
+
+export async function getOrganizationSettings(): Promise<OrganizationSettings> {
+  const { supabase } = await requireAuth();
+  const tenantId = await requireTenantId();
+
+  const { data, error } = await supabase
+    .from("organization_settings")
+    .select("*")
+    .eq("organization_id", tenantId)
+    .single();
+
+  if (error || !data) {
+    // Return defaults if no row exists
+    return {
+      organization_id: tenantId,
+      availability_lock_mode: "warn",
+      updated_at: new Date().toISOString(),
+    };
+  }
+  return data;
+}
+
+export async function updateAvailabilityLockMode(
+  mode: AvailabilityLockMode,
+): Promise<OrganizationSettings> {
+  const { supabase } = await requireAuth();
+  const tenantId = await requireTenantId();
+
+  const { data, error } = await supabase
+    .from("organization_settings")
+    .upsert(
+      {
+        organization_id: tenantId,
+        availability_lock_mode: mode,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "organization_id" },
+    )
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+  return data;
+}

--- a/lib/actions/organization-settings.ts
+++ b/lib/actions/organization-settings.ts
@@ -20,13 +20,13 @@ export async function getOrganizationSettings(): Promise<OrganizationSettings> {
   const { supabase } = await requireAuth();
   const tenantId = await requireTenantId();
 
-  const { data, error } = await supabase
+  const { data } = await supabase
     .from("organization_settings")
     .select("*")
     .eq("organization_id", tenantId)
-    .single();
+    .maybeSingle();
 
-  if (error || !data) {
+  if (!data) {
     // Return defaults if no row exists
     return {
       organization_id: tenantId,

--- a/lib/actions/organization-settings.ts
+++ b/lib/actions/organization-settings.ts
@@ -20,11 +20,13 @@ export async function getOrganizationSettings(): Promise<OrganizationSettings> {
   const { supabase } = await requireAuth();
   const tenantId = await requireTenantId();
 
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("organization_settings")
     .select("*")
     .eq("organization_id", tenantId)
     .maybeSingle();
+
+  if (error) throw new Error(error.message);
 
   if (!data) {
     // Return defaults if no row exists

--- a/lib/actions/public-poll-assignments.ts
+++ b/lib/actions/public-poll-assignments.ts
@@ -41,7 +41,7 @@ export async function getPollAssignmentContext(
     .from("organization_settings")
     .select("availability_lock_mode")
     .eq("organization_id", poll.organization_id)
-    .single();
+    .maybeSingle();
 
   const lockMode: AvailabilityLockMode =
     (settings?.availability_lock_mode as AvailabilityLockMode) ?? "warn";

--- a/lib/actions/public-poll-assignments.ts
+++ b/lib/actions/public-poll-assignments.ts
@@ -36,7 +36,19 @@ export async function getPollAssignmentContext(
     return { lockMode: "warn", assignedSlots: [] };
   }
 
-  // 2. Get organization settings
+  // 2. Validate the umpire belongs to this poll's organization
+  const { data: membership } = await supabase
+    .from("organization_umpires")
+    .select("umpire_id")
+    .eq("organization_id", poll.organization_id)
+    .eq("umpire_id", umpireId)
+    .maybeSingle();
+
+  if (!membership) {
+    return { lockMode: "warn", assignedSlots: [] };
+  }
+
+  // 3. Get organization settings
   const { data: settings } = await supabase
     .from("organization_settings")
     .select("availability_lock_mode")
@@ -46,7 +58,7 @@ export async function getPollAssignmentContext(
   const lockMode: AvailabilityLockMode =
     (settings?.availability_lock_mode as AvailabilityLockMode) ?? "warn";
 
-  // 3. Get assignments for this umpire in this poll
+  // 4. Get assignments for this umpire in this poll
   const { data: assignments } = await supabase
     .from("assignments")
     .select("match_id")
@@ -57,7 +69,7 @@ export async function getPollAssignmentContext(
     return { lockMode, assignedSlots: [] };
   }
 
-  // 4. Get matches and slots to build mapping
+  // 5. Get matches and slots to build mapping
   const matchIds = assignments.map((a) => a.match_id);
 
   const { data: matches } = await supabase
@@ -74,13 +86,13 @@ export async function getPollAssignmentContext(
     return { lockMode, assignedSlots: [] };
   }
 
-  // 5. Map matches to slots using existing domain function
+  // 6. Map matches to slots using existing domain function
   const matchToSlot = mapMatchesToSlots(
     matches as Match[],
     slots as PollSlot[],
   );
 
-  // 6. Build slotId -> match info map
+  // 7. Build slotId -> match info map
   const slotMap = new Map<
     string,
     { matchId: string; homeTeam: string; awayTeam: string }[]

--- a/lib/actions/public-poll-assignments.ts
+++ b/lib/actions/public-poll-assignments.ts
@@ -1,0 +1,110 @@
+"use server";
+
+import { createServiceClient } from "@/lib/supabase/service";
+import { mapMatchesToSlots } from "@/lib/domain/match-slot-mapping";
+import type { AvailabilityLockMode, Match, PollSlot } from "@/lib/types/domain";
+
+export type AssignedSlotInfo = {
+  slotId: string;
+  matches: { matchId: string; homeTeam: string; awayTeam: string }[];
+};
+
+export type PollAssignmentContext = {
+  lockMode: AvailabilityLockMode;
+  assignedSlots: AssignedSlotInfo[];
+};
+
+/**
+ * For a given poll and umpire, returns which slots have assignments
+ * and what the organization's lock mode is.
+ * Uses service role to bypass RLS (assignments table has no anon policy).
+ */
+export async function getPollAssignmentContext(
+  pollId: string,
+  umpireId: string,
+): Promise<PollAssignmentContext> {
+  const supabase = createServiceClient();
+
+  // 1. Get the poll's organization_id
+  const { data: poll } = await supabase
+    .from("polls")
+    .select("organization_id")
+    .eq("id", pollId)
+    .single();
+
+  if (!poll) {
+    return { lockMode: "warn", assignedSlots: [] };
+  }
+
+  // 2. Get organization settings
+  const { data: settings } = await supabase
+    .from("organization_settings")
+    .select("availability_lock_mode")
+    .eq("organization_id", poll.organization_id)
+    .single();
+
+  const lockMode: AvailabilityLockMode =
+    (settings?.availability_lock_mode as AvailabilityLockMode) ?? "warn";
+
+  // 3. Get assignments for this umpire in this poll
+  const { data: assignments } = await supabase
+    .from("assignments")
+    .select("match_id")
+    .eq("poll_id", pollId)
+    .eq("umpire_id", umpireId);
+
+  if (!assignments || assignments.length === 0) {
+    return { lockMode, assignedSlots: [] };
+  }
+
+  // 4. Get matches and slots to build mapping
+  const matchIds = assignments.map((a) => a.match_id);
+
+  const { data: matches } = await supabase
+    .from("matches")
+    .select("id, date, start_time, home_team, away_team")
+    .in("id", matchIds);
+
+  const { data: slots } = await supabase
+    .from("poll_slots")
+    .select("id, poll_id, start_time, end_time")
+    .eq("poll_id", pollId);
+
+  if (!matches || !slots) {
+    return { lockMode, assignedSlots: [] };
+  }
+
+  // 5. Map matches to slots using existing domain function
+  const matchToSlot = mapMatchesToSlots(
+    matches as Match[],
+    slots as PollSlot[],
+  );
+
+  // 6. Build slotId -> match info map
+  const slotMap = new Map<
+    string,
+    { matchId: string; homeTeam: string; awayTeam: string }[]
+  >();
+
+  for (const match of matches) {
+    const slotId = matchToSlot.get(match.id);
+    if (!slotId) continue;
+
+    const existing = slotMap.get(slotId) ?? [];
+    existing.push({
+      matchId: match.id,
+      homeTeam: match.home_team,
+      awayTeam: match.away_team,
+    });
+    slotMap.set(slotId, existing);
+  }
+
+  const assignedSlots: AssignedSlotInfo[] = Array.from(slotMap.entries()).map(
+    ([slotId, matchInfos]) => ({
+      slotId,
+      matches: matchInfos,
+    }),
+  );
+
+  return { lockMode, assignedSlots };
+}

--- a/lib/actions/public-polls.ts
+++ b/lib/actions/public-polls.ts
@@ -1,12 +1,16 @@
 "use server";
 
 import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { mapMatchesToSlots } from "@/lib/domain/match-slot-mapping";
 import { getTenantId } from "@/lib/tenant";
 import type {
   Poll,
   PollSlot,
+  Match,
   Umpire,
   AvailabilityResponse,
+  AvailabilityLockMode,
 } from "@/lib/types/domain";
 
 /* ------------------------------------------------------------------ */
@@ -177,6 +181,9 @@ export async function submitResponses(
   if (pollError || !poll) throw new Error("Poll not found");
   if (poll.status === "closed") throw new Error("Poll is closed");
 
+  // Check for assignment conflicts (uses service client to bypass RLS)
+  await checkAssignmentConflicts(pollId, umpireId, responses);
+
   // Upsert responses
   const rows = responses.map((r) => ({
     poll_id: pollId,
@@ -192,4 +199,128 @@ export async function submitResponses(
     .upsert(rows, { onConflict: "poll_id,slot_id,umpire_id" });
 
   if (error) throw new Error(error.message);
+}
+
+/* ------------------------------------------------------------------ */
+/*  checkAssignmentConflicts (internal)                                */
+/* ------------------------------------------------------------------ */
+
+async function checkAssignmentConflicts(
+  pollId: string,
+  umpireId: string,
+  newResponses: ResponseInput[],
+): Promise<void> {
+  const serviceClient = createServiceClient();
+
+  // Get assignments for this umpire in this poll
+  const { data: assignments } = await serviceClient
+    .from("assignments")
+    .select("match_id")
+    .eq("poll_id", pollId)
+    .eq("umpire_id", umpireId);
+
+  if (!assignments || assignments.length === 0) return;
+
+  // Get current (saved) responses for this umpire
+  const { data: currentResponses } = await serviceClient
+    .from("availability_responses")
+    .select("slot_id, response")
+    .eq("poll_id", pollId)
+    .eq("umpire_id", umpireId);
+
+  // Build a map of current slot responses
+  const currentMap = new Map<string, string>();
+  for (const r of currentResponses ?? []) {
+    currentMap.set(r.slot_id, r.response);
+  }
+
+  // Get matches and slots to build the match->slot mapping
+  const matchIds = assignments.map((a) => a.match_id);
+
+  const { data: matches } = await serviceClient
+    .from("matches")
+    .select("id, date, start_time, home_team, away_team")
+    .in("id", matchIds);
+
+  const { data: slots } = await serviceClient
+    .from("poll_slots")
+    .select("id, poll_id, start_time, end_time")
+    .eq("poll_id", pollId);
+
+  if (!matches || !slots) return;
+
+  const matchToSlot = mapMatchesToSlots(
+    matches as Match[],
+    slots as PollSlot[],
+  );
+
+  // Build slot->matchIds map for assigned slots
+  const assignedSlotMatches = new Map<string, string[]>();
+  for (const assignment of assignments) {
+    const slotId = matchToSlot.get(assignment.match_id);
+    if (!slotId) continue;
+    const existing = assignedSlotMatches.get(slotId) ?? [];
+    existing.push(assignment.match_id);
+    assignedSlotMatches.set(slotId, existing);
+  }
+
+  // Find downgrade conflicts: slots where response changes from yes/if_need_be to no
+  const conflictSlots: {
+    slotId: string;
+    matchIds: string[];
+    previousResponse: "yes" | "if_need_be";
+  }[] = [];
+
+  for (const resp of newResponses) {
+    if (resp.response !== "no") continue;
+    if (!assignedSlotMatches.has(resp.slotId)) continue;
+
+    const prev = currentMap.get(resp.slotId);
+    if (prev === "yes" || prev === "if_need_be") {
+      conflictSlots.push({
+        slotId: resp.slotId,
+        matchIds: assignedSlotMatches.get(resp.slotId)!,
+        previousResponse: prev,
+      });
+    }
+  }
+
+  if (conflictSlots.length === 0) return;
+
+  // Get organization's lock mode
+  const { data: pollData } = await serviceClient
+    .from("polls")
+    .select("organization_id")
+    .eq("id", pollId)
+    .single();
+
+  if (!pollData) return;
+
+  const { data: settings } = await serviceClient
+    .from("organization_settings")
+    .select("availability_lock_mode")
+    .eq("organization_id", pollData.organization_id)
+    .single();
+
+  const lockMode: AvailabilityLockMode =
+    (settings?.availability_lock_mode as AvailabilityLockMode) ?? "warn";
+
+  if (lockMode === "lock") {
+    throw new Error("AVAILABILITY_LOCKED");
+  }
+
+  // Warn mode: insert override log entries
+  const overrideRows = conflictSlots.flatMap((conflict) =>
+    conflict.matchIds.map((matchId) => ({
+      poll_id: pollId,
+      umpire_id: umpireId,
+      slot_id: conflict.slotId,
+      match_id: matchId,
+      previous_response: conflict.previousResponse,
+      new_response: "no",
+      organization_id: pollData.organization_id,
+    })),
+  );
+
+  await serviceClient.from("availability_override_logs").insert(overrideRows);
 }

--- a/lib/actions/public-polls.ts
+++ b/lib/actions/public-polls.ts
@@ -213,20 +213,23 @@ async function checkAssignmentConflicts(
   const serviceClient = createServiceClient();
 
   // Get assignments for this umpire in this poll
-  const { data: assignments } = await serviceClient
+  const { data: assignments, error: assignErr } = await serviceClient
     .from("assignments")
     .select("match_id")
     .eq("poll_id", pollId)
     .eq("umpire_id", umpireId);
 
+  if (assignErr) throw new Error("Failed to check assignments");
   if (!assignments || assignments.length === 0) return;
 
   // Get current (saved) responses for this umpire
-  const { data: currentResponses } = await serviceClient
+  const { data: currentResponses, error: respErr } = await serviceClient
     .from("availability_responses")
     .select("slot_id, response")
     .eq("poll_id", pollId)
     .eq("umpire_id", umpireId);
+
+  if (respErr) throw new Error("Failed to check current responses");
 
   // Build a map of current slot responses
   const currentMap = new Map<string, string>();
@@ -237,16 +240,17 @@ async function checkAssignmentConflicts(
   // Get matches and slots to build the match->slot mapping
   const matchIds = assignments.map((a) => a.match_id);
 
-  const { data: matches } = await serviceClient
+  const { data: matches, error: matchErr } = await serviceClient
     .from("matches")
     .select("id, date, start_time, home_team, away_team")
     .in("id", matchIds);
 
-  const { data: slots } = await serviceClient
+  const { data: slots, error: slotErr } = await serviceClient
     .from("poll_slots")
     .select("id, poll_id, start_time, end_time")
     .eq("poll_id", pollId);
 
+  if (matchErr || slotErr) throw new Error("Failed to load match/slot data");
   if (!matches || !slots) return;
 
   const matchToSlot = mapMatchesToSlots(
@@ -288,19 +292,19 @@ async function checkAssignmentConflicts(
   if (conflictSlots.length === 0) return;
 
   // Get organization's lock mode
-  const { data: pollData } = await serviceClient
+  const { data: pollData, error: pollErr } = await serviceClient
     .from("polls")
     .select("organization_id")
     .eq("id", pollId)
     .single();
 
-  if (!pollData) return;
+  if (pollErr || !pollData) throw new Error("Failed to load poll data");
 
   const { data: settings } = await serviceClient
     .from("organization_settings")
     .select("availability_lock_mode")
     .eq("organization_id", pollData.organization_id)
-    .single();
+    .maybeSingle();
 
   const lockMode: AvailabilityLockMode =
     (settings?.availability_lock_mode as AvailabilityLockMode) ?? "warn";
@@ -322,5 +326,9 @@ async function checkAssignmentConflicts(
     })),
   );
 
-  await serviceClient.from("availability_override_logs").insert(overrideRows);
+  const { error: insertErr } = await serviceClient
+    .from("availability_override_logs")
+    .insert(overrideRows);
+
+  if (insertErr) throw new Error("Failed to log availability override");
 }

--- a/lib/types/domain.ts
+++ b/lib/types/domain.ts
@@ -105,3 +105,23 @@ export type Assignment = {
   created_at: string;
   organization_id: string;
 };
+
+export type AvailabilityLockMode = "warn" | "lock";
+
+export type OrganizationSettings = {
+  organization_id: string;
+  availability_lock_mode: AvailabilityLockMode;
+  updated_at: string;
+};
+
+export type AvailabilityOverrideLog = {
+  id: string;
+  poll_id: string;
+  slot_id: string;
+  umpire_id: string;
+  match_id: string;
+  previous_response: "yes" | "if_need_be";
+  new_response: "no";
+  organization_id: string;
+  created_at: string;
+};

--- a/messages/en.json
+++ b/messages/en.json
@@ -89,7 +89,8 @@
     "activityAssignment": "{umpire} assigned to {homeTeam} vs {awayTeam}",
     "activityAssignmentsBatch": "{count, plural, one {# umpire} other {# umpires}} assigned",
     "activityMatchAdded": "Match added: {homeTeam} vs {awayTeam}",
-    "activityMatchesBatch": "{count, plural, one {# match} other {# matches}} added"
+    "activityMatchesBatch": "{count, plural, one {# match} other {# matches}} added",
+    "activityAvailabilityOverride": "{umpire} withdrew availability from {homeTeam} vs {awayTeam} despite being assigned"
   },
   "matches": {
     "pageTitle": "Matches",
@@ -317,7 +318,15 @@
     "couldNotResendCode": "Could not resend code. Please try again later.",
     "useDifferentEmail": "Use a different email",
     "pastDatesToggle": "{count, plural, one {# past date} other {# past dates}}",
-    "allDatesInPast": "All dates in this poll have passed. Your previous responses are shown below."
+    "allDatesInPast": "All dates in this poll have passed. Your previous responses are shown below.",
+    "slotLockedAssigned": "Locked — you're assigned to a match",
+    "assignedToMatch": "You are assigned to {match}",
+    "availabilityLockedError": "You cannot change your availability for slots where you are assigned. Contact the planner if you need to make changes.",
+    "warningDialogTitle": "Changing availability for assigned matches",
+    "warningDialogDescription": "You are about to mark yourself as unavailable for time slots where you have been assigned to matches.",
+    "warningDialogNotice": "The planner will be notified of this change.",
+    "warningDialogCancel": "Go back",
+    "warningDialogProceed": "Proceed anyway"
   },
   "umpires": {
     "pageTitle": "Umpires",
@@ -364,7 +373,14 @@
     "levelLabelTop": "Top",
     "addTeam": "Add team",
     "duplicateTeamName": "A team with this name already exists",
-    "teamError": "Something went wrong. Please try again."
+    "teamError": "Something went wrong. Please try again.",
+    "availabilityLockTitle": "Availability Protection",
+    "availabilityLockDescription": "Choose what happens when an umpire tries to mark themselves as unavailable for a slot where they are already assigned to a match.",
+    "lockModeWarn": "Warn",
+    "lockModeWarnDescription": "Show a warning, but allow the umpire to change their availability. You will be notified on the dashboard.",
+    "lockModeLock": "Lock",
+    "lockModeLockDescription": "Prevent the umpire from changing their availability for assigned slots entirely.",
+    "settingError": "Failed to save setting. Please try again."
   },
   "landing": {
     "title": "Fluitplanner",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -89,7 +89,8 @@
     "activityAssignment": "{umpire} ingedeeld bij {homeTeam} vs {awayTeam}",
     "activityAssignmentsBatch": "{count, plural, one {# scheidsrechter} other {# scheidsrechters}} ingedeeld",
     "activityMatchAdded": "Wedstrijd toegevoegd: {homeTeam} vs {awayTeam}",
-    "activityMatchesBatch": "{count, plural, one {# wedstrijd} other {# wedstrijden}} toegevoegd"
+    "activityMatchesBatch": "{count, plural, one {# wedstrijd} other {# wedstrijden}} toegevoegd",
+    "activityAvailabilityOverride": "{umpire} heeft beschikbaarheid ingetrokken voor {homeTeam} vs {awayTeam} ondanks indeling"
   },
   "matches": {
     "pageTitle": "Wedstrijden",
@@ -317,7 +318,15 @@
     "couldNotResendCode": "Code opnieuw versturen mislukt. Probeer het later opnieuw.",
     "useDifferentEmail": "Ander e-mailadres gebruiken",
     "pastDatesToggle": "{count, plural, one {# afgelopen datum} other {# afgelopen datums}}",
-    "allDatesInPast": "Alle datums in deze peiling zijn verstreken. Je eerdere reacties staan hieronder."
+    "allDatesInPast": "Alle datums in deze peiling zijn verstreken. Je eerdere reacties staan hieronder.",
+    "slotLockedAssigned": "Vergrendeld — je bent ingedeeld voor een wedstrijd",
+    "assignedToMatch": "Je bent ingedeeld voor {match}",
+    "availabilityLockedError": "Je kunt je beschikbaarheid niet wijzigen voor tijdsloten waarvoor je bent ingedeeld. Neem contact op met de planner als je wijzigingen wilt maken.",
+    "warningDialogTitle": "Beschikbaarheid wijzigen voor ingedeelde wedstrijden",
+    "warningDialogDescription": "Je staat op het punt jezelf als niet beschikbaar te markeren voor tijdsloten waarvoor je bent ingedeeld.",
+    "warningDialogNotice": "De planner wordt op de hoogte gesteld van deze wijziging.",
+    "warningDialogCancel": "Terug",
+    "warningDialogProceed": "Toch doorgaan"
   },
   "umpires": {
     "pageTitle": "Scheidsrechters",
@@ -364,7 +373,14 @@
     "levelLabelTop": "Top",
     "addTeam": "Team toevoegen",
     "duplicateTeamName": "Er bestaat al een team met deze naam",
-    "teamError": "Er is iets misgegaan. Probeer het opnieuw."
+    "teamError": "Er is iets misgegaan. Probeer het opnieuw.",
+    "availabilityLockTitle": "Beschikbaarheidsbescherming",
+    "availabilityLockDescription": "Kies wat er gebeurt als een scheidsrechter zich niet beschikbaar wil melden voor een tijdslot waarvoor hij of zij al is ingedeeld.",
+    "lockModeWarn": "Waarschuwen",
+    "lockModeWarnDescription": "Toon een waarschuwing, maar sta de scheidsrechter toe de beschikbaarheid te wijzigen. Je wordt op het dashboard op de hoogte gesteld.",
+    "lockModeLock": "Vergrendelen",
+    "lockModeLockDescription": "Voorkom dat de scheidsrechter de beschikbaarheid voor ingedeelde tijdsloten kan wijzigen.",
+    "settingError": "Instelling opslaan mislukt. Probeer het opnieuw."
   },
   "landing": {
     "title": "Fluitplanner",

--- a/supabase/migrations/20260224000001_availability_lock.sql
+++ b/supabase/migrations/20260224000001_availability_lock.sql
@@ -1,0 +1,63 @@
+-- Organization-level settings (1:1 with organizations, extensible for future settings)
+CREATE TABLE IF NOT EXISTS public.organization_settings (
+  organization_id uuid PRIMARY KEY REFERENCES public.organizations(id) ON DELETE CASCADE,
+  availability_lock_mode text NOT NULL DEFAULT 'warn'
+    CHECK (availability_lock_mode IN ('warn', 'lock')),
+  updated_at timestamptz DEFAULT now() NOT NULL
+);
+
+ALTER TABLE public.organization_settings ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users in the org can read and write settings
+CREATE POLICY "Tenant isolation for organization_settings"
+  ON public.organization_settings FOR ALL TO authenticated
+  USING (
+    organization_id IN (
+      SELECT organization_id FROM public.organization_members
+      WHERE user_id = auth.uid()
+    )
+  );
+
+-- Anon can read settings (needed for public poll page to determine lock mode)
+CREATE POLICY "Anon can select organization_settings"
+  ON public.organization_settings FOR SELECT TO anon
+  USING (true);
+
+-- Seed defaults for all existing organizations
+INSERT INTO public.organization_settings (organization_id)
+SELECT id FROM public.organizations
+ON CONFLICT DO NOTHING;
+
+-- Log table for when umpires override warnings (change availability despite being assigned)
+CREATE TABLE IF NOT EXISTS public.availability_override_logs (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  poll_id uuid NOT NULL REFERENCES public.polls(id) ON DELETE CASCADE,
+  slot_id uuid NOT NULL REFERENCES public.poll_slots(id) ON DELETE CASCADE,
+  umpire_id uuid NOT NULL REFERENCES public.umpires(id) ON DELETE CASCADE,
+  match_id uuid NOT NULL REFERENCES public.matches(id) ON DELETE CASCADE,
+  previous_response text NOT NULL CHECK (previous_response IN ('yes', 'if_need_be')),
+  new_response text NOT NULL DEFAULT 'no' CHECK (new_response IN ('no')),
+  organization_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  created_at timestamptz DEFAULT now() NOT NULL
+);
+
+CREATE INDEX idx_override_logs_org ON public.availability_override_logs (organization_id);
+CREATE INDEX idx_override_logs_poll ON public.availability_override_logs (poll_id);
+CREATE INDEX idx_override_logs_recent ON public.availability_override_logs (organization_id, created_at DESC);
+
+ALTER TABLE public.availability_override_logs ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users in the org can read override logs
+CREATE POLICY "Tenant isolation for availability_override_logs"
+  ON public.availability_override_logs FOR SELECT TO authenticated
+  USING (
+    organization_id IN (
+      SELECT organization_id FROM public.organization_members
+      WHERE user_id = auth.uid()
+    )
+  );
+
+-- Anon can insert override logs (umpires submitting from public poll page)
+CREATE POLICY "Anon can insert override logs"
+  ON public.availability_override_logs FOR INSERT TO anon
+  WITH CHECK (true);

--- a/supabase/migrations/20260224000001_availability_lock.sql
+++ b/supabase/migrations/20260224000001_availability_lock.sql
@@ -8,9 +8,9 @@ CREATE TABLE IF NOT EXISTS public.organization_settings (
 
 ALTER TABLE public.organization_settings ENABLE ROW LEVEL SECURITY;
 
--- Authenticated users in the org can read and write settings
-CREATE POLICY "Tenant isolation for organization_settings"
-  ON public.organization_settings FOR ALL TO authenticated
+-- Authenticated users in the org can read settings
+CREATE POLICY "Members can select organization_settings"
+  ON public.organization_settings FOR SELECT TO authenticated
   USING (
     organization_id IN (
       SELECT organization_id FROM public.organization_members
@@ -18,10 +18,39 @@ CREATE POLICY "Tenant isolation for organization_settings"
     )
   );
 
--- Anon can read settings (needed for public poll page to determine lock mode)
-CREATE POLICY "Anon can select organization_settings"
-  ON public.organization_settings FOR SELECT TO anon
-  USING (true);
+-- Authenticated users in the org can update settings
+CREATE POLICY "Members can update organization_settings"
+  ON public.organization_settings FOR UPDATE TO authenticated
+  USING (
+    organization_id IN (
+      SELECT organization_id FROM public.organization_members
+      WHERE user_id = auth.uid()
+    )
+  );
+
+-- Authenticated users in the org can insert settings (for initial seed)
+CREATE POLICY "Members can insert organization_settings"
+  ON public.organization_settings FOR INSERT TO authenticated
+  WITH CHECK (
+    organization_id IN (
+      SELECT organization_id FROM public.organization_members
+      WHERE user_id = auth.uid()
+    )
+  );
+
+-- Auto-update updated_at on modification
+CREATE OR REPLACE FUNCTION public.update_organization_settings_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_organization_settings_updated_at
+  BEFORE UPDATE ON public.organization_settings
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_organization_settings_updated_at();
 
 -- Seed defaults for all existing organizations
 INSERT INTO public.organization_settings (organization_id)
@@ -29,19 +58,19 @@ SELECT id FROM public.organizations
 ON CONFLICT DO NOTHING;
 
 -- Log table for when umpires override warnings (change availability despite being assigned)
+-- Foreign keys use SET NULL to preserve audit trail when referenced entities are deleted.
 CREATE TABLE IF NOT EXISTS public.availability_override_logs (
   id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
-  poll_id uuid NOT NULL REFERENCES public.polls(id) ON DELETE CASCADE,
-  slot_id uuid NOT NULL REFERENCES public.poll_slots(id) ON DELETE CASCADE,
-  umpire_id uuid NOT NULL REFERENCES public.umpires(id) ON DELETE CASCADE,
-  match_id uuid NOT NULL REFERENCES public.matches(id) ON DELETE CASCADE,
+  poll_id uuid REFERENCES public.polls(id) ON DELETE SET NULL,
+  slot_id uuid REFERENCES public.poll_slots(id) ON DELETE SET NULL,
+  umpire_id uuid REFERENCES public.umpires(id) ON DELETE SET NULL,
+  match_id uuid REFERENCES public.matches(id) ON DELETE SET NULL,
   previous_response text NOT NULL CHECK (previous_response IN ('yes', 'if_need_be')),
   new_response text NOT NULL DEFAULT 'no' CHECK (new_response IN ('no')),
   organization_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
   created_at timestamptz DEFAULT now() NOT NULL
 );
 
-CREATE INDEX idx_override_logs_org ON public.availability_override_logs (organization_id);
 CREATE INDEX idx_override_logs_poll ON public.availability_override_logs (poll_id);
 CREATE INDEX idx_override_logs_recent ON public.availability_override_logs (organization_id, created_at DESC);
 
@@ -57,7 +86,5 @@ CREATE POLICY "Tenant isolation for availability_override_logs"
     )
   );
 
--- Anon can insert override logs (umpires submitting from public poll page)
-CREATE POLICY "Anon can insert override logs"
-  ON public.availability_override_logs FOR INSERT TO anon
-  WITH CHECK (true);
+-- No anon policies: all override log inserts go through the service role client
+-- which bypasses RLS, so no anon INSERT policy is needed.


### PR DESCRIPTION
## Summary
This PR implements an availability lock system that prevents umpires from withdrawing availability for time slots where they have already been assigned to matches. Organizations can configure whether to warn umpires about conflicts (warn mode) or completely prevent changes (lock mode).

## Key Changes

### Core Feature
- **Availability Lock Modes**: Added two configurable modes via `organization_settings` table:
  - `warn`: Umpires can change availability but are warned and changes are logged
  - `lock`: Umpires cannot modify availability for assigned slots (UI disabled)

### Backend Implementation
- **Conflict Detection** (`lib/actions/public-polls.ts`): New `checkAssignmentConflicts()` function validates availability changes against existing assignments before submission
- **Assignment Context** (`lib/actions/public-poll-assignments.ts`): New `getPollAssignmentContext()` server action retrieves which slots have assignments and the organization's lock mode
- **Override Logging**: New `availability_override_logs` table tracks when umpires change availability despite being assigned (for audit/analytics)
- **Organization Settings** (`lib/actions/organization-settings.ts`): New actions to read/update lock mode settings

### Frontend Implementation
- **Form Behavior** (`components/poll-response/availability-form.tsx`):
  - Lock mode: Assigned slots are disabled and grayed out with lock icon
  - Warn mode: Shows warning dialog before submission if umpire is downgrading assigned slots
  - Displays affected match information in warnings
- **Slot Row UI** (`components/poll-response/slot-row.tsx`): Added visual indicators for locked slots and warning badges for pending overrides
- **Warning Dialog** (`components/poll-response/assignment-warning-dialog.tsx`): Confirmation dialog showing affected matches before allowing override submission
- **Settings UI** (`components/settings/availability-lock-setting.tsx`): Radio group to configure lock mode per organization

### Dashboard & Monitoring
- **Activity Tracking** (`lib/actions/dashboard.ts`): 
  - New action item type for availability overrides
  - New activity event type showing when umpires withdraw availability despite assignments
- **Recent Activity Display** (`components/dashboard/recent-activity-section.tsx`): Visual indicator for override events

### Database
- New `organization_settings` table (1:1 with organizations) for extensible settings
- New `availability_override_logs` table with RLS policies for audit trail
- Proper indexing on organization_id and created_at for performance

### Internationalization
- Added translation keys for lock mode UI, warnings, and activity descriptions (English and Dutch)

## Notable Implementation Details
- Uses service client to bypass RLS when checking assignments (assignments table has no anon policy)
- Leverages existing `mapMatchesToSlots()` domain function to correlate matches with poll time slots
- Override logs are inserted even in warn mode for audit purposes
- Graceful degradation: if no assignments exist, no conflicts are checked
- Settings default to "warn" mode for backward compatibility

https://claude.ai/code/session_01KGQYbAC3QDwZxYM9RHmhxc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Availability Protection setting added to org settings (Warn / Lock) with persisted choice
  * Assignment-aware availability form: locked slots become uneditable; warn mode shows a confirmation dialog before override
  * New assignment warning dialog listing affected matches
  * Recent Activity & Dashboard now surface "availability override" events with an alert icon and highlight

* **Localization**
  * New translation keys for availability lock UI and warning dialog

* **Audit / Backend**
  * Overrides are recorded for auditing; org settings and assignment context are available server-side

* **Tests**
  * Expanded test mocks to cover service-layer assignment and override scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->