### PR TITLE
fix: remove type re-export from server action to fix SSR runtime error

### DIFF
--- a/lib/actions/public-poll-assignments.ts
+++ b/lib/actions/public-poll-assignments.ts
@@ -11,9 +11,6 @@ import {
   type PollAssignmentContext,
 } from "@/lib/types/domain";
 
-// Re-export types for consumers
-export type { AssignedSlotInfo, PollAssignmentContext };
-
 /**
  * For a given poll and umpire, returns which slots have assignments
  * and what the organization's lock mode is.


### PR DESCRIPTION
## Summary
- Removes `export type { AssignedSlotInfo, PollAssignmentContext }` re-export from `lib/actions/public-poll-assignments.ts`
- Turbopack compiled this type-only re-export as a value export in the SSR bundle, causing `ReferenceError: AssignedSlotInfo is not defined` when umpires tried to access a poll
- Consumers already import these types from `@/lib/types/domain` directly, so the re-export was unnecessary

## Test plan
- [ ] Navigate to a poll as an umpire and enter email — verify no error occurs
- [ ] Verify availability form loads correctly after identification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code organization updates.

---

**Note:** This release contains no user-visible changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->