### PR TITLE
fix: use service client in linkUmpireToOrg to bypass RLS

### DIFF
--- a/__tests__/lib/actions/public-polls.test.ts
+++ b/__tests__/lib/actions/public-polls.test.ts
@@ -37,12 +37,19 @@ vi.mock("@/lib/supabase/server", () => ({
   })),
 }));
 
+const mockServiceSingle = vi.fn().mockResolvedValue({
+  data: null,
+  error: null,
+});
+const mockServiceUpsert = vi.fn().mockResolvedValue({ error: null });
+
 const mockServiceFrom = vi.fn(() => ({
   select: vi.fn().mockReturnThis(),
   eq: vi.fn().mockReturnThis(),
   in: vi.fn().mockReturnThis(),
-  single: vi.fn().mockResolvedValue({ data: null, error: null }),
+  single: mockServiceSingle,
   insert: vi.fn().mockResolvedValue({ error: null }),
+  upsert: mockServiceUpsert,
   maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
 }));
 
@@ -65,6 +72,9 @@ function resetChain() {
     mockOrder,
     mockInsert,
     mockUpsert,
+    mockServiceFrom,
+    mockServiceSingle,
+    mockServiceUpsert,
   ]) {
     fn.mockReset();
   }
@@ -76,6 +86,18 @@ function resetChain() {
   mockInsert.mockReturnValue(chainable());
   mockUpsert.mockReturnValue(chainable());
   mockSingle.mockResolvedValue({ data: null, error: null });
+  // Restore service client defaults
+  mockServiceFrom.mockReturnValue({
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    single: mockServiceSingle,
+    insert: vi.fn().mockResolvedValue({ error: null }),
+    upsert: mockServiceUpsert,
+    maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+  });
+  mockServiceSingle.mockResolvedValue({ data: null, error: null });
+  mockServiceUpsert.mockResolvedValue({ error: null });
 }
 
 beforeEach(() => {
@@ -205,15 +227,15 @@ describe("findOrCreateUmpire", () => {
       updated_at: "2026-01-01T00:00:00Z",
     };
 
-    // First call: lookup umpire → found
+    // Regular client: lookup umpire → found
     mockSingle.mockResolvedValueOnce({ data: umpire, error: null });
-    // Second call: linkUmpireToOrg → polls lookup returns org id
-    mockSingle.mockResolvedValueOnce({
+    // Service client: linkUmpireToOrg → polls lookup returns org id
+    mockServiceSingle.mockResolvedValueOnce({
       data: { organization_id: "org-123" },
       error: null,
     });
-    // Third call: upsert to organization_umpires
-    mockUpsert.mockResolvedValueOnce({ error: null });
+    // Service client: upsert to organization_umpires
+    mockServiceUpsert.mockResolvedValueOnce({ error: null });
 
     const { findOrCreateUmpire } = await import("@/lib/actions/public-polls");
     const result = await findOrCreateUmpire(
@@ -223,9 +245,9 @@ describe("findOrCreateUmpire", () => {
     );
     expect(result).toEqual(umpire);
 
-    // Verify polls lookup and org_umpires upsert were called
-    expect(mockFrom).toHaveBeenCalledWith("polls");
-    expect(mockFrom).toHaveBeenCalledWith("organization_umpires");
+    // Verify polls lookup and org_umpires upsert were called via service client
+    expect(mockServiceFrom).toHaveBeenCalledWith("polls");
+    expect(mockServiceFrom).toHaveBeenCalledWith("organization_umpires");
   });
 
   it("skips org linking when poll has no organization_id", async () => {
@@ -239,10 +261,10 @@ describe("findOrCreateUmpire", () => {
       updated_at: "2026-01-01T00:00:00Z",
     };
 
-    // Lookup umpire → found
+    // Regular client: lookup umpire → found
     mockSingle.mockResolvedValueOnce({ data: umpire, error: null });
-    // linkUmpireToOrg → polls lookup returns null org
-    mockSingle.mockResolvedValueOnce({
+    // Service client: linkUmpireToOrg → polls lookup returns null org
+    mockServiceSingle.mockResolvedValueOnce({
       data: { organization_id: null },
       error: null,
     });
@@ -256,7 +278,7 @@ describe("findOrCreateUmpire", () => {
     expect(result).toEqual(umpire);
 
     // org_umpires upsert should NOT have been called
-    expect(mockFrom).not.toHaveBeenCalledWith("organization_umpires");
+    expect(mockServiceFrom).not.toHaveBeenCalledWith("organization_umpires");
   });
 });
 

--- a/components/poll-response/poll-response-page.tsx
+++ b/components/poll-response/poll-response-page.tsx
@@ -122,8 +122,9 @@ export function PollResponsePage({
         .then((ctx) => {
           if (!cancelled) setAssignmentContext(ctx);
         })
-        .catch(() => {
+        .catch((err) => {
           // Gracefully degrade: no lock/warn enforcement on fetch failure
+          console.error("Failed to fetch assignment context:", err);
           if (!cancelled) setAssignmentContext(null);
         });
     } else {

--- a/lib/actions/public-poll-assignments.ts
+++ b/lib/actions/public-poll-assignments.ts
@@ -33,19 +33,7 @@ export async function getPollAssignmentContext(
     return { lockMode: "warn", assignedSlots: [] };
   }
 
-  // 2. Validate the umpire belongs to this poll's organization
-  const { data: membership } = await supabase
-    .from("organization_umpires")
-    .select("umpire_id")
-    .eq("organization_id", poll.organization_id)
-    .eq("umpire_id", umpireId)
-    .maybeSingle();
-
-  if (!membership) {
-    return { lockMode: "warn", assignedSlots: [] };
-  }
-
-  // 3. Get organization settings
+  // 2. Get organization settings
   const { data: settings } = await supabase
     .from("organization_settings")
     .select("availability_lock_mode")

--- a/lib/actions/public-polls.ts
+++ b/lib/actions/public-polls.ts
@@ -81,7 +81,7 @@ export async function findOrCreateUmpire(
 
   if (!error && existing) {
     // Link existing umpire to the poll's organization if not already linked
-    if (pollId) await linkUmpireToOrg(supabase, existing.id, pollId);
+    if (pollId) await linkUmpireToOrg(existing.id, pollId);
     return existing;
   }
 
@@ -97,29 +97,39 @@ export async function findOrCreateUmpire(
   if (insertError || !created) return null;
 
   // Link new umpire to the poll's organization
-  if (pollId) await linkUmpireToOrg(supabase, created.id, pollId);
+  if (pollId) await linkUmpireToOrg(created.id, pollId);
   return created;
 }
 
 async function linkUmpireToOrg(
-  supabase: Awaited<ReturnType<typeof createClient>>,
   umpireId: string,
   pollId: string,
 ): Promise<void> {
-  const { data: poll } = await supabase
+  // Use service client to bypass RLS — poll respondents are anonymous
+  // and organization_umpires only allows authenticated users
+  const supabase = createServiceClient();
+
+  const { data: poll, error: pollError } = await supabase
     .from("polls")
     .select("organization_id")
     .eq("id", pollId)
     .single();
 
-  if (!poll?.organization_id) return;
+  if (pollError || !poll?.organization_id) {
+    console.error("linkUmpireToOrg: failed to fetch poll", pollError);
+    return;
+  }
 
-  await supabase
+  const { error: upsertError } = await supabase
     .from("organization_umpires")
     .upsert(
       { organization_id: poll.organization_id, umpire_id: umpireId },
       { onConflict: "organization_id,umpire_id" },
     );
+
+  if (upsertError) {
+    console.error("linkUmpireToOrg: failed to upsert membership", upsertError);
+  }
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- **`linkUmpireToOrg`** used the regular Supabase client (anon session for poll respondents), but `organization_umpires` RLS only allows authenticated users — the upsert silently failed, so umpires were never linked to their organization
- This broke both the **availability lock mode** (umpires saw no locked/grayed-out slots after being assigned) and the **umpires list** on the planner dashboard (anonymous poll respondents were invisible)
- Switch `linkUmpireToOrg` to `createServiceClient()` to bypass RLS, add error checking on poll lookup and upsert
- Remove redundant `organization_umpires` membership check in `getPollAssignmentContext` (the assignments query already implicitly validates membership)
- Add `console.error` to the assignment context fetch catch block for future debugging

## Test plan
- [x] All 349 unit/component tests pass
- [x] Production build succeeds
- [ ] After deploy: verify new poll respondents appear in the planner's umpires list
- [ ] After deploy: verify assigned umpires see locked/warned slots in polls
- [ ] Backfill existing umpire-org links via SQL for umpires who responded before the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and logging when retrieving assignment context
  * Improved error logging for poll organization linking operations

* **Changes**
  * Removed organization membership validation requirement from poll assignment process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->