### PR TITLE
feat: local Supabase dev instance with Podman

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,12 @@
-# Supabase
+# Supabase (remote)
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# --- Local Supabase (run `supabase start`, then `supabase status` for keys) ---
+# NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+# NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<anon-key-from-supabase-status>
+# SUPABASE_SERVICE_ROLE_KEY=<service-role-key-from-supabase-status>
 
 # SMTP (e.g. AWS SES)
 SMTP_HOST=email-smtp.eu-west-1.amazonaws.com

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ dist/
 # supabase
 supabase/.branches
 supabase/.temp
+supabase/seed.sql
 
 # debug / logs
 npm-debug.log*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ npm run format         # Format all files with Prettier
 npm run format:check   # Check formatting without writing
 npm test               # Run unit/component tests (vitest)
 npm run test:watch     # Watch mode for TDD red/green cycles
-npm run test:e2e       # Run E2E tests (playwright, starts dev server)
+npm run test:e2e       # Run E2E tests (playwright, production build)
+npm run test:e2e:dev   # Run E2E tests against dev server (faster)
 npm run type-check     # TypeScript type checking
 npm run supabase:start # Start local Supabase (requires Podman)
 npm run supabase:stop  # Stop local Supabase

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,15 +18,19 @@ Never commit directly to `main`. Always create a feature branch before making an
 ## Commands
 
 ```bash
-npm run dev        # Start dev server (localhost:3000)
-npm run build      # Production build
-npm run lint       # ESLint
-npm run format     # Format all files with Prettier
-npm run format:check # Check formatting without writing
-npm test           # Run unit/component tests (vitest)
-npm run test:watch # Watch mode for TDD red/green cycles
-npm run test:e2e   # Run E2E tests (playwright, starts dev server)
-npm run type-check # TypeScript type checking
+npm run dev            # Start dev server (localhost:3000)
+npm run build          # Production build
+npm run lint           # ESLint
+npm run format         # Format all files with Prettier
+npm run format:check   # Check formatting without writing
+npm test               # Run unit/component tests (vitest)
+npm run test:watch     # Watch mode for TDD red/green cycles
+npm run test:e2e       # Run E2E tests (playwright, starts dev server)
+npm run type-check     # TypeScript type checking
+npm run supabase:start # Start local Supabase (requires Podman)
+npm run supabase:stop  # Stop local Supabase
+npm run supabase:reset # Re-apply migrations + seed data
+npm run supabase:seed  # Dump production data to supabase/seed.sql
 ```
 
 Use red/green TDD per `app_description.md`: write a failing test first, then implement.
@@ -80,14 +84,25 @@ CI (GitHub Actions) runs lint, format check, type check, tests, and build on eve
 - `/auth/*` — login, sign-up, forgot-password, update-password, confirmation
 - `/protected/*` — authenticated pages (layout includes nav with auth button)
 
+### Local Supabase Development
+
+Local dev uses **Podman** (not Docker) to run the full Supabase stack locally. Config: `supabase/config.toml`. Migrations: `supabase/migrations/`.
+
+- **Start**: `npm run supabase:start` (requires Podman machine running)
+- **Seed from production**: `npm run supabase:seed` then `npm run supabase:reset`
+- `supabase/seed.sql` is gitignored (contains production data)
+- Local services: API on `:54321`, DB on `:54322`, Studio on `:54323`, Mailpit (email) on `:54324`
+- If `supabase start` fails with "Cannot connect to Docker daemon", set `export DOCKER_HOST=unix:///var/run/docker.sock`
+- E2E tests and dev server both use the local instance via `.env.local` credentials
+
 ### Environment Variables
 
 Required in `.env.local`:
 
-- `NEXT_PUBLIC_SUPABASE_URL`
-- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`
+- `NEXT_PUBLIC_SUPABASE_URL` — local: `http://127.0.0.1:54321`, remote: `https://<project>.supabase.co`
+- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` — from `supabase status` (local) or Supabase dashboard (remote)
 - `SUPABASE_SERVICE_ROLE_KEY` — service role key for server-side operations that bypass RLS
-- `SMTP_HOST` — AWS SES SMTP host (e.g. `email-smtp.eu-west-1.amazonaws.com`)
+- `SMTP_HOST` — AWS SES SMTP host (not needed locally — Mailpit captures emails)
 - `SMTP_PORT` — SMTP port (587)
 - `SMTP_USER` — SES SMTP username
 - `SMTP_PASS` — SES SMTP password

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,14 +86,14 @@ CI (GitHub Actions) runs lint, format check, type check, tests, and build on eve
 
 ### Local Supabase Development
 
-Local dev uses **Podman** (not Docker) to run the full Supabase stack locally. Config: `supabase/config.toml`. Migrations: `supabase/migrations/`.
+Local dev uses **Podman** (not Docker) to run the full Supabase stack locally. See [`docs/local-supabase.md`](docs/local-supabase.md) for full setup guide, troubleshooting, and seeding instructions.
+
+Quick reference:
 
 - **Start**: `npm run supabase:start` (requires Podman machine running)
 - **Seed from production**: `npm run supabase:seed` then `npm run supabase:reset`
-- `supabase/seed.sql` is gitignored (contains production data)
-- Local services: API on `:54321`, DB on `:54322`, Studio on `:54323`, Mailpit (email) on `:54324`
-- If `supabase start` fails with "Cannot connect to Docker daemon", set `export DOCKER_HOST=unix:///var/run/docker.sock`
-- E2E tests and dev server both use the local instance via `.env.local` credentials
+- **Local services**: API `:54321`, DB `:54322`, Studio `:54323`, Mailpit `:54324`
+- **E2E tests**: `npm run test:e2e` (production build) or `npm run test:e2e:dev` (dev server)
 
 ### Environment Variables
 

--- a/docs/local-supabase.md
+++ b/docs/local-supabase.md
@@ -41,10 +41,10 @@ SMTP variables are not needed locally — Mailpit captures all emails.
 
 | Service  | URL                    | Purpose                                         |
 | -------- | ---------------------- | ----------------------------------------------- |
-| API      | http://localhost:54321 | Supabase REST/Auth API                          |
-| Database | localhost:54322        | PostgreSQL (user: `postgres`, pass: `postgres`) |
-| Studio   | http://localhost:54323 | Database admin UI                               |
-| Mailpit  | http://localhost:54324 | Email capture (replaces SES)                    |
+| API      | http://127.0.0.1:54321 | Supabase REST/Auth API                          |
+| Database | 127.0.0.1:54322        | PostgreSQL (user: `postgres`, pass: `postgres`) |
+| Studio   | http://127.0.0.1:54323 | Database admin UI                               |
+| Mailpit  | http://127.0.0.1:54324 | Email capture (replaces SES)                    |
 
 ## Convenience Scripts
 
@@ -97,10 +97,10 @@ Migrations live in `supabase/migrations/`. To create a new migration:
 supabase migration new <name>
 ```
 
-To apply migrations without re-seeding:
+To apply pending migrations locally without re-seeding:
 
 ```bash
-supabase db push
+supabase migration up --local
 ```
 
 ## Troubleshooting

--- a/docs/local-supabase.md
+++ b/docs/local-supabase.md
@@ -1,0 +1,137 @@
+# Local Supabase Development with Podman
+
+This project uses a local Supabase instance for development and E2E testing, running on **Podman** (not Docker).
+
+## Prerequisites
+
+- **Podman** installed and machine running: `podman machine start`
+- **Supabase CLI**: `brew install supabase/tap/supabase`
+
+## Quick Start
+
+```bash
+# 1. Start the local Supabase stack
+npm run supabase:start
+
+# 2. Seed with production data (first time only)
+npm run supabase:seed    # dumps remote data to supabase/seed.sql
+npm run supabase:reset   # applies migrations + seed
+
+# 3. Update .env.local with local credentials
+# Copy values from `supabase status` output (see below)
+
+# 4. Start the dev server
+npm run dev
+```
+
+## Environment Setup
+
+After `supabase start`, run `supabase status` to get the local keys. Update `.env.local`:
+
+```env
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<anon key from supabase status>
+SUPABASE_SERVICE_ROLE_KEY=<service_role key from supabase status>
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+```
+
+SMTP variables are not needed locally — Mailpit captures all emails.
+
+## Local Services
+
+| Service  | URL                    | Purpose                                         |
+| -------- | ---------------------- | ----------------------------------------------- |
+| API      | http://localhost:54321 | Supabase REST/Auth API                          |
+| Database | localhost:54322        | PostgreSQL (user: `postgres`, pass: `postgres`) |
+| Studio   | http://localhost:54323 | Database admin UI                               |
+| Mailpit  | http://localhost:54324 | Email capture (replaces SES)                    |
+
+## Convenience Scripts
+
+| Script                   | Command                                            |
+| ------------------------ | -------------------------------------------------- |
+| `npm run supabase:start` | Start all local Supabase containers                |
+| `npm run supabase:stop`  | Stop all containers                                |
+| `npm run supabase:reset` | Re-apply all migrations + seed data                |
+| `npm run supabase:seed`  | Dump remote production data to `supabase/seed.sql` |
+
+## Seeding
+
+`supabase/seed.sql` contains a full data dump from production and is **gitignored** (sensitive data). To create or refresh it:
+
+```bash
+npm run supabase:seed    # creates/overwrites supabase/seed.sql
+npm run supabase:reset   # drops DB, re-applies migrations, then runs seed.sql
+```
+
+After reset, you can verify data in Studio at http://localhost:54323.
+
+## E2E Tests
+
+E2E tests run against the local Supabase instance. The test setup (`e2e/global-setup.ts`) automatically:
+
+1. Creates an E2E test user (`e2e-test@fluitplanner.test`) if it doesn't exist
+2. Ensures the test user has `planner` role in the `default` organization
+3. Saves authenticated browser state to `e2e/.auth/state.json`
+
+```bash
+npm run test:e2e       # production build — reliable, for CI
+npm run test:e2e:dev   # dev server — fast iteration when writing tests
+```
+
+The production build (`test:e2e`) uses `npm run build && npm run start` to avoid Turbopack dev-mode SSR quirks. The dev variant (`test:e2e:dev`) reuses a running `npm run dev` process for speed.
+
+## Database Access
+
+Connect directly to the local PostgreSQL:
+
+```bash
+PGPASSWORD=postgres psql -h 127.0.0.1 -p 54322 -U postgres -d postgres
+```
+
+## Migrations
+
+Migrations live in `supabase/migrations/`. To create a new migration:
+
+```bash
+supabase migration new <name>
+```
+
+To apply migrations without re-seeding:
+
+```bash
+supabase db push
+```
+
+## Troubleshooting
+
+### "Cannot connect to Docker daemon"
+
+Supabase CLI looks for the Docker socket at `~/.docker/run/docker.sock`, but Podman exposes it at `/var/run/docker.sock`. Fix:
+
+```bash
+export DOCKER_HOST=unix:///var/run/docker.sock
+```
+
+Add this to your shell profile (`.zshrc` / `.bashrc`) to make it permanent.
+
+### Podman machine stopped / containers gone
+
+```bash
+podman machine stop
+podman machine start
+supabase stop    # clean up stale state
+supabase start   # re-pull and start containers
+```
+
+### Port conflicts
+
+If ports 54321-54324 are in use, stop any other Supabase/Docker instances first:
+
+```bash
+supabase stop --no-backup
+```
+
+### Switching between local and remote
+
+To switch back to the remote Supabase instance, update `.env.local` with the remote credentials (available in the Supabase dashboard). The remote values are commented out in `.env.example` for reference.

--- a/e2e/assignments.spec.ts
+++ b/e2e/assignments.spec.ts
@@ -15,12 +15,13 @@ test.describe("Umpire Assignment", () => {
       return;
     }
 
-    // Click on first poll to go to detail
-    await rows.first().click();
+    // Click on first poll title to go to detail (not the row — checkbox intercepts)
+    await rows.first().locator("td").nth(1).click();
+    await page.waitForURL(/\/protected\/polls\//);
 
     // Click Assignments tab
     const assignmentsTab = page.getByRole("tab", { name: /assignments/i });
-    await expect(assignmentsTab).toBeVisible();
+    await expect(assignmentsTab).toBeVisible({ timeout: 10000 });
     await assignmentsTab.click();
 
     // The assignment grid should now be visible (either with cells or empty message)
@@ -37,40 +38,75 @@ test.describe("Umpire Assignment", () => {
     expect(hasCells || hasEmptyMessage).toBeTruthy();
   });
 
-  test("planner can assign and unassign umpires", async ({ page }) => {
-    await page.goto("/protected/polls");
+  test.describe("assign and unassign flow", () => {
+    test.describe.configure({ mode: "serial" });
 
-    const rows = page.locator("table tbody tr");
-    const rowCount = await rows.count();
-    if (rowCount === 0) {
-      test.skip(true, "No polls available to test assignments");
-      return;
-    }
+    const uniqueId = Date.now();
+    const pollTitle = `E2E Assignment Poll ${uniqueId}`;
+    let pollUrl = "";
+    let pollCreated = false;
 
-    await rows.first().click();
+    test("create a poll owned by test user", async ({ page }) => {
+      await page.goto("/protected/polls/new");
+      await page.getByLabel("Poll Title").fill(pollTitle);
 
-    // Click Assignments tab
-    await page.getByRole("tab", { name: /assignments/i }).click();
+      const checkboxes = page.getByRole("checkbox");
+      const count = await checkboxes.count();
+      if (count === 0) {
+        test.skip(true, "No matches available to create a poll");
+        return;
+      }
 
-    // Check if there are any assignment cells
-    const firstCell = page.locator('[data-testid^="cell-"]').first();
-    const hasCells = await firstCell.isVisible().catch(() => false);
+      // Select first match
+      await checkboxes.first().click();
+      await page.getByRole("button", { name: "Create Poll" }).click();
 
-    if (!hasCells) {
-      test.skip(true, "No umpire responses — cannot test assignment toggle");
-      return;
-    }
+      // Should redirect to detail page
+      await expect(page.getByText(pollTitle)).toBeVisible();
+      pollUrl = page.url();
+      pollCreated = true;
+    });
 
-    // Click a cell to assign
-    await firstCell.click();
+    test("planner can assign and unassign umpires", async ({ page }) => {
+      test.skip(!pollCreated, "Poll was not created");
 
-    // Verify an icon appears (checkmark, ban, or warning)
-    await expect(firstCell.locator("svg")).toBeVisible();
+      // Navigate to the poll we just created (owned by E2E test user)
+      await page.goto(pollUrl);
 
-    // Click again to unassign
-    await firstCell.click();
+      // Click Assignments tab
+      await page
+        .getByRole("tab", { name: /assignments/i })
+        .click({ timeout: 10000 });
 
-    // Verify icon is gone
-    await expect(firstCell.locator("svg")).not.toBeVisible();
+      // Check if there are any assignment cells
+      const firstCell = page.locator('[data-testid^="cell-"]').first();
+      const hasCells = await firstCell.isVisible().catch(() => false);
+
+      if (!hasCells) {
+        test.skip(true, "No umpire responses — cannot test assignment toggle");
+        return;
+      }
+
+      // Click a cell to assign
+      await firstCell.click();
+
+      // Verify an icon appears (checkmark, ban, or warning)
+      await expect(firstCell.locator("svg")).toBeVisible();
+
+      // Click again to unassign
+      await firstCell.click();
+
+      // Verify icon is gone
+      await expect(firstCell.locator("svg")).not.toBeVisible();
+    });
+
+    test("cleanup: delete poll", async ({ page }) => {
+      test.skip(!pollCreated, "Poll was not created");
+
+      await page.goto(pollUrl);
+      page.on("dialog", (dialog) => dialog.accept());
+      await page.getByRole("button", { name: /delete/i }).click();
+      await page.waitForURL(/\/protected\/polls$/);
+    });
   });
 });

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -20,11 +20,15 @@ async function globalSetup(config: FullConfig) {
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!supabaseUrl || !supabaseKey) {
     throw new Error(
       "Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
     );
+  }
+  if (!serviceRoleKey) {
+    throw new Error("Missing SUPABASE_SERVICE_ROLE_KEY (needed for E2E setup)");
   }
 
   const testEmail = process.env.E2E_TEST_EMAIL ?? "e2e-test@fluitplanner.test";
@@ -66,6 +70,36 @@ async function globalSetup(config: FullConfig) {
       );
     }
   }
+
+  // Ensure test user has org membership (middleware auto-join can silently fail)
+  const serviceClient = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  // Get user ID from the signed-in session
+  const {
+    data: { user: testUser },
+  } = await supabase.auth.getUser();
+  if (!testUser) throw new Error("Failed to get test user after sign-in");
+
+  // Look up the "default" organization
+  const { data: org } = await serviceClient
+    .from("organizations")
+    .select("id")
+    .eq("slug", "default")
+    .single();
+
+  if (!org) throw new Error('Organization "default" not found in database');
+
+  // Ensure test user is a planner in the default org
+  await serviceClient.from("organization_members").upsert(
+    {
+      organization_id: org.id,
+      user_id: testUser.id,
+      role: "planner",
+    },
+    { onConflict: "organization_id,user_id" },
+  );
 
   // Use browser to log in and capture authenticated state (cookies/localStorage)
   const browser = await chromium.launch();

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -92,14 +92,18 @@ async function globalSetup(config: FullConfig) {
   if (!org) throw new Error('Organization "default" not found in database');
 
   // Ensure test user is a planner in the default org
-  await serviceClient.from("organization_members").upsert(
-    {
-      organization_id: org.id,
-      user_id: testUser.id,
-      role: "planner",
-    },
-    { onConflict: "organization_id,user_id" },
-  );
+  const { error: upsertError } = await serviceClient
+    .from("organization_members")
+    .upsert(
+      {
+        organization_id: org.id,
+        user_id: testUser.id,
+        role: "planner",
+      },
+      { onConflict: "organization_id,user_id" },
+    );
+  if (upsertError)
+    throw new Error(`Failed to upsert org membership: ${upsertError.message}`);
 
   // Use browser to log in and capture authenticated state (cookies/localStorage)
   const browser = await chromium.launch();

--- a/e2e/poll-response.spec.ts
+++ b/e2e/poll-response.spec.ts
@@ -1,9 +1,13 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type BrowserContext, type Page } from "@playwright/test";
 
 test.describe("Poll response page", () => {
-  test("shows not found for invalid token", async ({ page }) => {
+  test("shows not found for invalid token", async ({ browser }) => {
+    // Poll pages are public — test without auth to match real umpire usage
+    const context = await browser.newContext();
+    const page = await context.newPage();
     await page.goto("/poll/nonexistent-token-xyz");
     await expect(page.getByText("Poll not found")).toBeVisible();
+    await context.close();
   });
 
   test.describe("full poll response flow", () => {
@@ -15,6 +19,10 @@ test.describe("Poll response page", () => {
     const umpireName = `E2E Umpire ${uniqueId}`;
     let pollToken = "";
     let pollCreated = false;
+
+    // Shared unauthenticated context for umpire tests (preserves cookies)
+    let umpireContext: BrowserContext;
+    let umpirePage: Page;
 
     test("planner creates a poll and gets share link", async ({ page }) => {
       await page.goto("/protected/polls/new");
@@ -50,56 +58,67 @@ test.describe("Poll response page", () => {
       pollCreated = true;
     });
 
-    test("umpire can fill out availability via poll link", async ({ page }) => {
+    test("umpire can fill out availability via poll link", async ({
+      browser,
+    }) => {
       test.skip(!pollCreated, "Poll was not created");
 
-      await page.goto(`/poll/${pollToken}`);
-      await expect(page.getByText(pollTitle)).toBeVisible();
+      // Create unauthenticated context that will persist across serial tests
+      umpireContext = await browser.newContext();
+      umpirePage = await umpireContext.newPage();
+
+      await umpirePage.goto(`/poll/${pollToken}`);
+      await expect(umpirePage.getByText(pollTitle)).toBeVisible();
 
       // Enter email (new umpire)
-      await page.getByLabel("Your email").fill(umpireEmail);
-      await page.getByRole("button", { name: "Continue" }).click();
+      await umpirePage.getByLabel("Your email").fill(umpireEmail);
+      await umpirePage.getByRole("button", { name: "Continue" }).click();
 
       // Should ask for name (new umpire)
-      await expect(page.getByLabel("Your name")).toBeVisible();
-      await page.getByLabel("Your name").fill(umpireName);
-      await page.getByRole("button", { name: "Continue" }).click();
+      await expect(umpirePage.getByLabel("Your name")).toBeVisible();
+      await umpirePage.getByLabel("Your name").fill(umpireName);
+      await umpirePage.getByRole("button", { name: "Continue" }).click();
 
-      // Should show availability form
-      await expect(page.getByText("Responding as:")).toBeVisible();
-      await expect(page.getByText(umpireName)).toBeVisible();
+      // Should show availability form with umpire name
+      await expect(
+        umpirePage.getByText(`Responding as ${umpireName}`),
+      ).toBeVisible();
 
       // Click Yes on the first slot
-      const yesButtons = page.getByRole("button", { name: "Yes" });
+      const yesButtons = umpirePage.getByRole("button", { name: "Yes" });
       await yesButtons.first().click();
 
       // Save
-      await page.getByRole("button", { name: /save/i }).click();
-      await expect(page.getByText(/saved/i)).toBeVisible();
+      await umpirePage.getByRole("button", { name: /save/i }).click();
+      await expect(umpirePage.getByText(/saved/i)).toBeVisible();
     });
 
-    test("returning umpire sees existing responses", async ({ page }) => {
+    test("returning umpire sees existing responses", async () => {
       test.skip(!pollCreated, "Poll was not created");
 
-      // Visit same poll (cookie should still be set from previous test)
-      await page.goto(`/poll/${pollToken}`);
+      // Re-use the same context so the umpire cookie persists
+      await umpirePage.goto(`/poll/${pollToken}`);
 
-      await expect(page.getByText(umpireName)).toBeVisible({ timeout: 10000 });
-      await expect(page.getByText("Responding as:")).toBeVisible();
+      await expect(
+        umpirePage.getByText(`Responding as ${umpireName}`),
+      ).toBeVisible({ timeout: 10000 });
     });
 
     test("closed poll shows closed message", async ({ page }) => {
       test.skip(!pollCreated, "Poll was not created");
 
-      // Close the poll via planner
+      // Close the poll via planner (authenticated context)
       await page.goto("/protected/polls");
       await page.getByText(pollTitle).click();
       await page.getByRole("button", { name: /close poll/i }).click();
       await expect(page.getByText("Closed")).toBeVisible();
 
-      // Visit the public poll link
-      await page.goto(`/poll/${pollToken}`);
-      await expect(page.getByText("This poll is closed")).toBeVisible();
+      // Visit the public poll link using the umpire context
+      await umpirePage.goto(`/poll/${pollToken}`);
+      await expect(umpirePage.getByText("Poll closed")).toBeVisible();
+
+      // Cleanup umpire context
+      await umpireContext.close();
 
       // Cleanup: reopen and delete
       await page.goto("/protected/polls");

--- a/lib/actions/polls.ts
+++ b/lib/actions/polls.ts
@@ -523,7 +523,11 @@ export async function deletePoll(pollId: string): Promise<void> {
   const tenantId = await requireTenantId();
 
   // Delete availability responses (FK doesn't cascade)
-  await supabase.from("availability_responses").delete().eq("poll_id", pollId);
+  const { error: respDeleteError } = await supabase
+    .from("availability_responses")
+    .delete()
+    .eq("poll_id", pollId);
+  if (respDeleteError) throw new Error(respDeleteError.message);
 
   const { error } = await supabase
     .from("polls")
@@ -542,7 +546,11 @@ export async function deletePolls(pollIds: string[]): Promise<void> {
   const tenantId = await requireTenantId();
 
   // Delete availability responses (FK doesn't cascade)
-  await supabase.from("availability_responses").delete().in("poll_id", pollIds);
+  const { error: respDeleteError } = await supabase
+    .from("availability_responses")
+    .delete()
+    .in("poll_id", pollIds);
+  if (respDeleteError) throw new Error(respDeleteError.message);
 
   const { error } = await supabase
     .from("polls")

--- a/lib/actions/polls.ts
+++ b/lib/actions/polls.ts
@@ -522,6 +522,9 @@ export async function deletePoll(pollId: string): Promise<void> {
   const { supabase } = await requireAuth();
   const tenantId = await requireTenantId();
 
+  // Delete availability responses (FK doesn't cascade)
+  await supabase.from("availability_responses").delete().eq("poll_id", pollId);
+
   const { error } = await supabase
     .from("polls")
     .delete()
@@ -537,6 +540,9 @@ export async function deletePolls(pollIds: string[]): Promise<void> {
     throw new Error("Cannot delete more than 500 items at once");
   const { supabase } = await requireAuth();
   const tenantId = await requireTenantId();
+
+  // Delete availability responses (FK doesn't cascade)
+  await supabase.from("availability_responses").delete().in("poll_id", pollIds);
 
   const { error } = await supabase
     .from("polls")

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "supabase:start": "supabase start",
+    "supabase:stop": "supabase stop",
+    "supabase:reset": "supabase db reset",
+    "supabase:seed": "supabase db dump --data-only -f supabase/seed.sql"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
+    "test:e2e:dev": "playwright test --config=playwright.dev.config.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,9 +13,10 @@ export default defineConfig({
     trace: "on-first-retry",
   },
   webServer: {
-    command: "npm run dev",
+    command: "npm run build && npm run start",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
   },
   projects: [
     {

--- a/playwright.dev.config.ts
+++ b/playwright.dev.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "@playwright/test";
+import baseConfig from "./playwright.config";
+
+/**
+ * Dev-mode Playwright config for fast iteration when writing tests.
+ * Uses `npm run dev` instead of a production build.
+ *
+ * Usage: npm run test:e2e:dev
+ */
+export default defineConfig({
+  ...baseConfig,
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: true,
+    timeout: 30_000,
+  },
+});


### PR DESCRIPTION
## Summary
- Set up local Supabase development using Podman for fully offline dev and E2E testing
- Fixed all E2E test failures (RLS policy issues, cookie persistence, incorrect assertions)
- Fixed `deletePoll`/`deletePolls` bug where deleting a poll with availability responses would fail due to non-cascading FK constraint
- Added `test:e2e:dev` script for fast iteration when writing tests (uses dev server instead of production build)

## Changes
- **Local Supabase**: convenience scripts (`supabase:start/stop/reset/seed`), updated `.env.example` with local config comments, `seed.sql` in `.gitignore`
- **E2E fixes**: assignments test creates own poll for RLS compliance, poll-response tests share browser context for cookie persistence, production build for reliable E2E runs
- **Bug fix**: `deletePoll`/`deletePolls` now delete `availability_responses` before the poll (FK doesn't cascade)
- **DX**: `playwright.dev.config.ts` for dev-mode E2E testing, updated `CLAUDE.md` with local Supabase docs

## Test plan
- [x] `npm run test:e2e` — 21 passed, 1 skipped, 0 failures
- [ ] Verify `supabase start` works on a fresh clone (requires Podman)
- [ ] Verify `npm run test:e2e:dev` works with `npm run dev` running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added npm scripts for local Supabase management and a dev E2E test runner.

* **Bug Fixes**
  * Ensures related poll data is cleaned up when polls are deleted to prevent integrity issues.

* **Tests**
  * E2E flows improved for assignment and public response scenarios; test setup made more reliable.

* **Documentation**
  * Added detailed local Supabase developer guide and updated CLI/environment guidance.

* **Chores**
  * Seed data file is now ignored by version control; test runner web server now builds before start.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->