### PR TITLE
chore: optimize CLAUDE.md for agent efficiency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,111 +1,21 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+## Rules
 
-## Project Overview
+- **Never commit to `main`**. Always create a feature branch and use PRs.
+- **Conventional commits** required (`feat:`, `fix:`, `chore:`, `test:`, `docs:`) — drives release-please.
+- **Never skip pre-commit hooks** (`--no-verify`). They run ESLint + Prettier.
+- **TDD**: write a failing test first, then implement (see `app_description.md`).
 
-Fluitplanner: a field hockey umpire availability and match assignment app. Two interfaces:
+## Footgun Prevention
 
-1. **Planner (admin)**: upload matches (excel/csv/paste), CRUD matches & umpires, assign umpires to matches, generate availability poll links
-2. **Umpire (user)**: mobile-responsive availability polls (yes/if need be/no) for time slots, similar to Rallly/Doodle
+- **Supabase server client**: always `await createClient()` fresh per request — never cache in a global (Fluid Compute reuses processes).
+- **TailwindCSS v4**: CSS-first config in `app/globals.css` via `@theme inline`. There is no `tailwind.config.ts` — don't create one.
+- **shadcn/ui**: components use `data-slot` attributes, not `forwardRef`.
+- **next-intl**: uses "without i18n routing" — cookie-based locale, no `[locale]` URL segment. Don't add locale to routes.
+- **Date/time formatting**: always use `hour12: false` (Dutch locale, 24h clock). Don't use `format.dateTime()` for machine-parseable values (e.g. `<input type="time">`).
+- **Dependencies**: pin with caret ranges (`^1.2.3`), never `"latest"` — breaks `npm ci`.
 
-Availability polls use 2-hour time slots (not exact match times). Slots start at least 20 min before match time, rounded down to nearest quarter hour. Each match requires two umpires.
+## Reference
 
-## Git Workflow
-
-Never commit directly to `main`. Always create a feature branch before making any changes (e.g., `git checkout -b feat/my-feature`). Use pull requests to merge into `main`.
-
-## Commands
-
-```bash
-npm run dev            # Start dev server (localhost:3000)
-npm run build          # Production build
-npm run lint           # ESLint
-npm run format         # Format all files with Prettier
-npm run format:check   # Check formatting without writing
-npm test               # Run unit/component tests (vitest)
-npm run test:watch     # Watch mode for TDD red/green cycles
-npm run test:e2e       # Run E2E tests (playwright, production build)
-npm run test:e2e:dev   # Run E2E tests against dev server (faster)
-npm run type-check     # TypeScript type checking
-npm run supabase:start # Start local Supabase (requires Podman)
-npm run supabase:stop  # Stop local Supabase
-npm run supabase:reset # Re-apply migrations + seed data
-npm run supabase:seed  # Dump production data to supabase/seed.sql
-```
-
-Use red/green TDD per `app_description.md`: write a failing test first, then implement.
-
-### Code Quality
-
-Pre-commit hook (husky + lint-staged) automatically runs ESLint and Prettier on staged files. Do not skip hooks with `--no-verify`.
-
-CI (GitHub Actions) runs lint, format check, type check, tests, and build on every PR and push to main. Releases are managed by release-please using conventional commits — use prefixes like `feat:`, `fix:`, `chore:`, `docs:`, `test:`.
-
-### Test Structure
-
-- `__tests__/` — unit tests (mirror source structure)
-- `components/__tests__/` — component tests (colocated)
-- `e2e/` — Playwright E2E tests
-- Config: `vitest.config.ts`, `playwright.config.ts`
-
-## Tech Stack & Architecture
-
-- **Next.js** (App Router) on **Vercel** with Fluid Compute
-- **Supabase** for database, auth, and backend (via `@supabase/ssr`)
-- **TailwindCSS v4** with CSS-first configuration (no `tailwind.config.ts`). All theme config is in `app/globals.css` via `@theme inline`. Dark mode uses `@custom-variant dark` with class strategy.
-- **shadcn/ui** (new-york style, RSC-enabled) — add components via `npx shadcn@latest add <component>`. Components use `data-slot` attributes (not `forwardRef`).
-- **next-themes** for dark/light mode switching
-- **next-intl** for i18n (English + Dutch), cookie-based locale without URL routing
-
-## Key Patterns
-
-### Supabase Client Creation
-
-- **Server**: `import { createClient } from "@/lib/supabase/server"` — always `await createClient()` fresh per request (never store in a global due to Fluid Compute)
-- **Client**: `import { createClient } from "@/lib/supabase/client"` — browser client
-- **Proxy** (`proxy.ts`): refreshes auth sessions, redirects unauthenticated users to `/auth/login` (except `/` and `/auth/*` routes)
-
-### i18n (next-intl)
-
-- Uses "without i18n routing" — locale stored in a cookie, no `[locale]` URL segment
-- Messages: `messages/en.json` and `messages/nl.json` — flat namespace keys (e.g., `"nav"`, `"dashboard"`, `"polls"`)
-- Server components: `const t = await getTranslations("namespace")`
-- Client components: `const t = useTranslations("namespace")`
-- `LocaleDetector` component auto-detects browser language on first visit
-- `LanguageSwitcher` toggle in nav and footer
-
-### Path Aliases
-
-`@/*` maps to project root (e.g., `@/components`, `@/lib`)
-
-### Route Structure
-
-- `/` — public landing page
-- `/auth/*` — login, sign-up, forgot-password, update-password, confirmation
-- `/protected/*` — authenticated pages (layout includes nav with auth button)
-
-### Local Supabase Development
-
-Local dev uses **Podman** (not Docker) to run the full Supabase stack locally. See [`docs/local-supabase.md`](docs/local-supabase.md) for full setup guide, troubleshooting, and seeding instructions.
-
-Quick reference:
-
-- **Start**: `npm run supabase:start` (requires Podman machine running)
-- **Seed from production**: `npm run supabase:seed` then `npm run supabase:reset`
-- **Local services**: API `:54321`, DB `:54322`, Studio `:54323`, Mailpit `:54324`
-- **E2E tests**: `npm run test:e2e` (production build) or `npm run test:e2e:dev` (dev server)
-
-### Environment Variables
-
-Required in `.env.local`:
-
-- `NEXT_PUBLIC_SUPABASE_URL` — local: `http://127.0.0.1:54321`, remote: `https://<project>.supabase.co`
-- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` — from `supabase status` (local) or Supabase dashboard (remote)
-- `SUPABASE_SERVICE_ROLE_KEY` — service role key for server-side operations that bypass RLS
-- `SMTP_HOST` — AWS SES SMTP host (not needed locally — Mailpit captures emails)
-- `SMTP_PORT` — SMTP port (587)
-- `SMTP_USER` — SES SMTP username
-- `SMTP_PASS` — SES SMTP password
-- `SMTP_FROM` — sender address (e.g. `Fluitplanner <noreply@fluitplanner.nl>`)
-- `NEXT_PUBLIC_SITE_URL` — base URL for magic links (e.g. `https://fluitplanner.nl`)
+See [REFERENCE.md](REFERENCE.md) for architecture, commands, environment variables, test patterns, and local dev setup.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1,0 +1,104 @@
+# Reference
+
+Detailed project context for Fluitplanner. See [CLAUDE.md](CLAUDE.md) for critical rules.
+
+## Project Overview
+
+Fluitplanner: a field hockey umpire availability and match assignment app.
+
+1. **Planner (admin)**: upload matches (Excel/CSV/paste), CRUD matches & umpires, assign umpires to matches, generate availability poll links
+2. **Umpire (user)**: mobile-responsive availability polls (yes/if need be/no) for time slots, similar to Rallly/Doodle
+
+Availability polls use 2-hour time slots (not exact match times). Slots start at least 20 min before match time, rounded down to nearest quarter hour. Each match requires two umpires.
+
+## Commands
+
+```bash
+npm run dev            # Start dev server (localhost:3000)
+npm run build          # Production build
+npm run lint           # ESLint
+npm run format         # Format all files with Prettier
+npm run format:check   # Check formatting without writing
+npm test               # Run unit/component tests (vitest)
+npm run test:watch     # Watch mode for TDD red/green cycles
+npm run test:e2e       # Run E2E tests (playwright, production build)
+npm run test:e2e:dev   # Run E2E tests against dev server (faster)
+npm run type-check     # TypeScript type checking
+npm run supabase:start # Start local Supabase (requires Podman)
+npm run supabase:stop  # Stop local Supabase
+npm run supabase:reset # Re-apply migrations + seed data
+npm run supabase:seed  # Dump production data to supabase/seed.sql
+```
+
+## Tech Stack
+
+- **Next.js** (App Router) on **Vercel** with Fluid Compute
+- **Supabase** for database, auth, and backend (via `@supabase/ssr`)
+- **TailwindCSS v4** — CSS-first config in `app/globals.css`. Dark mode via `@custom-variant dark` (class strategy).
+- **shadcn/ui** (new-york style, RSC-enabled) — `npx shadcn@latest add <component>`
+- **next-themes** for dark/light mode switching
+- **next-intl** for i18n (English + Dutch)
+
+## Key Patterns
+
+### Supabase Client
+
+- **Server**: `import { createClient } from "@/lib/supabase/server"` — `await createClient()` per request
+- **Client**: `import { createClient } from "@/lib/supabase/client"`
+- **Proxy** (`proxy.ts`): refreshes auth sessions, redirects unauthenticated users to `/auth/login`
+- **Server actions**: use `"use server"` + `requireAuth()` helper
+
+### i18n (next-intl)
+
+- Config: `i18n/request.ts`, messages: `messages/en.json` + `messages/nl.json`
+- Flat namespace keys (e.g., `"nav"`, `"dashboard"`, `"polls"`)
+- Server: `const t = await getTranslations("namespace")`
+- Client: `const t = useTranslations("namespace")`
+- Date/time: `useFormatter()`/`getFormatter()` with `hour12: false`
+- `LocaleDetector` auto-detects browser language; `LanguageSwitcher` in nav + footer
+
+### Route Structure
+
+- `/` — public landing page
+- `/auth/*` — login, sign-up, forgot-password, update-password, confirmation
+- `/protected/*` — authenticated pages (layout includes nav with auth button)
+
+### Test Structure
+
+- `__tests__/` — unit tests (mirror source structure)
+- `components/__tests__/` — component tests (colocated)
+- `e2e/` — Playwright E2E tests
+- Config: `vitest.config.ts`, `playwright.config.ts`
+- Test render helper: `__tests__/helpers/render.tsx` (wraps with NextIntlClientProvider)
+- Server component tests: mock `next-intl/server` with `vi.mock`
+- E2E unauthenticated: `test.use({ storageState: { cookies: [], origins: [] } })`
+- E2E authenticated: global auth state in `e2e/.auth/state.json`
+
+### Error Handling
+
+- Dashboard uses Suspense streaming — each section in its own `<Suspense>` boundary
+- Error boundaries: thin `error.tsx` wrappers around shared `ErrorBoundaryContent`
+
+### CI/CD
+
+- GitHub Actions: lint, format check, type check, tests, build on every PR and push to main
+- Releases managed by release-please using conventional commits
+
+## Local Supabase Development
+
+Uses **Podman** (not Docker). See [`docs/local-supabase.md`](docs/local-supabase.md) for full guide.
+
+- **Start**: `npm run supabase:start` (requires Podman machine running)
+- **Seed from production**: `npm run supabase:seed` then `npm run supabase:reset`
+- **Local services**: API `:54321`, DB `:54322`, Studio `:54323`, Mailpit `:54324`
+
+## Environment Variables
+
+Required in `.env.local`:
+
+- `NEXT_PUBLIC_SUPABASE_URL` — local: `http://127.0.0.1:54321`, remote: `https://<project>.supabase.co`
+- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` — from `supabase status` or Supabase dashboard
+- `SUPABASE_SERVICE_ROLE_KEY` — service role key for server-side operations bypassing RLS
+- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` — AWS SES (not needed locally, Mailpit captures emails)
+- `SMTP_FROM` — sender address (e.g. `Fluitplanner <noreply@fluitplanner.nl>`)
+- `NEXT_PUBLIC_SITE_URL` — base URL for magic links (e.g. `https://fluitplanner.nl`)


### PR DESCRIPTION
## Summary
- Slimmed CLAUDE.md from 112 lines to ~20 lines of critical rules and non-obvious pitfalls
- Extracted architecture, commands, env vars, test patterns, and local dev setup to REFERENCE.md
- Added 3 new rules from learned experience: `hour12: false`, no `format.dateTime()` for machine values, caret-pinned dependencies

## Rationale
Only instructions that prevent costly or hard-to-reverse mistakes stay in CLAUDE.md. Everything discoverable from code/configs moves to REFERENCE.md, reducing agent token cost per task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive reference documentation covering project architecture, development workflow, tech stack, and local setup instructions
  * Reorganized internal guidelines with new sections for rules and best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->