### PR TITLE
feat: add day sheet export for simplified per-date match overview

### DIFF
--- a/__tests__/lib/export/prepare-export-data.test.ts
+++ b/__tests__/lib/export/prepare-export-data.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   prepareResponseExport,
   prepareAssignmentExport,
+  prepareDaySheetExport,
 } from "@/lib/export/prepare-export-data";
 import type {
   PollSlot,
@@ -447,5 +448,192 @@ describe("prepareAssignmentExport", () => {
     expect(result.rows[0].venue).toBe("");
     expect(result.rows[0].field).toBe("");
     expect(result.rows[0].competition).toBe("");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  prepareDaySheetExport                                              */
+/* ------------------------------------------------------------------ */
+
+describe("prepareDaySheetExport", () => {
+  const baseMatch: Match = {
+    id: "m1",
+    date: "2026-03-15",
+    start_time: "2026-03-15T14:00:00Z",
+    home_team: "Team A",
+    away_team: "Team B",
+    competition: "League",
+    venue: "Stadium",
+    field: "1",
+    required_level: 1,
+    created_by: "user1",
+    created_at: "",
+    organization_id: "org1",
+  };
+
+  const baseUmpire: Umpire = {
+    id: "u1",
+    auth_user_id: null,
+    name: "Alice",
+    email: "alice@example.com",
+    level: 1,
+    created_at: "",
+    updated_at: "",
+  };
+
+  it("filters matches to the given date", () => {
+    const matches: Match[] = [
+      { ...baseMatch, id: "m1", date: "2026-03-15" },
+      { ...baseMatch, id: "m2", date: "2026-03-16" },
+      { ...baseMatch, id: "m3", date: "2026-03-15" },
+    ];
+
+    const result = prepareDaySheetExport(
+      "Poll",
+      matches,
+      [],
+      [],
+      fmtDate,
+      fmtTime,
+      "2026-03-15",
+    );
+    expect(result.rows).toHaveLength(2);
+  });
+
+  it("returns empty rows when no matches on the given date", () => {
+    const result = prepareDaySheetExport(
+      "Poll",
+      [baseMatch],
+      [],
+      [],
+      fmtDate,
+      fmtTime,
+      "2026-03-20",
+    );
+    expect(result.rows).toHaveLength(0);
+  });
+
+  it("combines home and away teams into match column", () => {
+    const result = prepareDaySheetExport(
+      "Poll",
+      [baseMatch],
+      [],
+      [],
+      fmtDate,
+      fmtTime,
+      "2026-03-15",
+    );
+    expect(result.rows[0].match).toBe("Team A - Team B");
+  });
+
+  it("includes field in output", () => {
+    const result = prepareDaySheetExport(
+      "Poll",
+      [baseMatch],
+      [],
+      [],
+      fmtDate,
+      fmtTime,
+      "2026-03-15",
+    );
+    expect(result.rows[0].field).toBe("1");
+  });
+
+  it("resolves assigned umpire names", () => {
+    const umpires: Umpire[] = [
+      { ...baseUmpire, id: "u1", name: "Alice" },
+      { ...baseUmpire, id: "u2", name: "Bob" },
+    ];
+    const assignments: Assignment[] = [
+      {
+        id: "a1",
+        poll_id: "p1",
+        match_id: "m1",
+        umpire_id: "u2",
+        created_at: "",
+        organization_id: "org1",
+      },
+      {
+        id: "a2",
+        poll_id: "p1",
+        match_id: "m1",
+        umpire_id: "u1",
+        created_at: "",
+        organization_id: "org1",
+      },
+    ];
+
+    const result = prepareDaySheetExport(
+      "Poll",
+      [baseMatch],
+      assignments,
+      umpires,
+      fmtDate,
+      fmtTime,
+      "2026-03-15",
+    );
+    expect(result.rows[0].umpire1).toBe("Alice");
+    expect(result.rows[0].umpire2).toBe("Bob");
+  });
+
+  it("sorts matches by start_time within the day", () => {
+    const matches: Match[] = [
+      {
+        ...baseMatch,
+        id: "m2",
+        start_time: "2026-03-15T16:00:00Z",
+      },
+      {
+        ...baseMatch,
+        id: "m1",
+        start_time: "2026-03-15T10:00:00Z",
+      },
+    ];
+
+    const result = prepareDaySheetExport(
+      "Poll",
+      matches,
+      [],
+      [],
+      fmtDate,
+      fmtTime,
+      "2026-03-15",
+    );
+    expect(result.rows[0].time).toBe("2026-03-15T10:00:00Z");
+    expect(result.rows[1].time).toBe("2026-03-15T16:00:00Z");
+  });
+
+  it("uses formatted date in output", () => {
+    const customFmtDate = () => "Sat 15 Mar";
+    const result = prepareDaySheetExport(
+      "Poll",
+      [baseMatch],
+      [],
+      [],
+      customFmtDate,
+      fmtTime,
+      "2026-03-15",
+    );
+    expect(result.date).toBe("Sat 15 Mar");
+  });
+
+  it("uses empty string for null fields", () => {
+    const match: Match = {
+      ...baseMatch,
+      start_time: null,
+      field: null,
+    };
+
+    const result = prepareDaySheetExport(
+      "Poll",
+      [match],
+      [],
+      [],
+      fmtDate,
+      fmtTime,
+      "2026-03-15",
+    );
+    expect(result.rows[0].time).toBe("");
+    expect(result.rows[0].field).toBe("");
   });
 });

--- a/components/polls/export-dropdown.tsx
+++ b/components/polls/export-dropdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   Download,
   FileSpreadsheet,
@@ -8,6 +8,7 @@ import {
   Code,
   Copy,
   Check,
+  CalendarDays,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -17,6 +18,9 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useTranslations, useFormatter, useLocale } from "next-intl";
@@ -31,14 +35,17 @@ import type {
 import {
   prepareResponseExport,
   prepareAssignmentExport,
+  prepareDaySheetExport,
 } from "@/lib/export/prepare-export-data";
 import {
   generateResponseHtml,
   generateAssignmentHtml,
+  generateDaySheetHtml,
 } from "@/lib/export/generators/html";
 import {
   generateResponseMarkdown,
   generateAssignmentMarkdown,
+  generateDaySheetMarkdown,
 } from "@/lib/export/generators/markdown";
 import {
   downloadBlob,
@@ -72,15 +79,6 @@ export function ExportDropdown({
   const locale = useLocale();
   const [copiedMd, setCopiedMd] = useState(false);
 
-  const target: ExportTarget | null =
-    activeTab === "responses"
-      ? "responses"
-      : activeTab === "assignments"
-        ? "assignments"
-        : null;
-
-  if (!target) return null;
-
   function formatDate(iso: string): string {
     return format.dateTime(new Date(iso), {
       weekday: "short",
@@ -96,6 +94,23 @@ export function ExportDropdown({
       hour12: false,
     });
   }
+
+  // Extract unique dates from matches for day sheet sub-menu
+  // Must be before early return to satisfy React hooks rules
+  const uniqueDates = useMemo(() => {
+    const dates = [...new Set(matches.map((m) => m.date))].sort();
+    return dates.map((d) => ({ iso: d, label: formatDate(d) }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [matches]);
+
+  const target: ExportTarget | null =
+    activeTab === "responses"
+      ? "responses"
+      : activeTab === "assignments"
+        ? "assignments"
+        : null;
+
+  if (!target) return null;
 
   const responseLabels = {
     yes: t("availableLabel"),
@@ -116,6 +131,15 @@ export function ExportDropdown({
     umpire1: t("exportUmpire1"),
     umpire2: t("exportUmpire2"),
     count: t("exportCount"),
+    noData: t("noDataToExport"),
+  };
+
+  const daySheetColumnLabels = {
+    time: t("exportTime"),
+    match: t("daySheetMatch"),
+    field: t("exportField"),
+    umpire1: t("exportUmpire1"),
+    umpire2: t("exportUmpire2"),
     noData: t("noDataToExport"),
   };
 
@@ -140,6 +164,18 @@ export function ExportDropdown({
       umpires,
       formatDate,
       formatTime,
+    );
+  }
+
+  function getDaySheetData(filterDate: string) {
+    return prepareDaySheetExport(
+      pollTitle,
+      matches,
+      assignments,
+      umpires,
+      formatDate,
+      formatTime,
+      filterDate,
     );
   }
 
@@ -215,6 +251,57 @@ export function ExportDropdown({
     }
   }
 
+  async function handleDaySheetXlsx(filterDate: string) {
+    try {
+      const { generateDaySheetXlsx } =
+        await import("@/lib/export/generators/xlsx");
+      const data = getDaySheetData(filterDate);
+      const blob = await generateDaySheetXlsx(data, daySheetColumnLabels);
+      downloadBlob(blob, `${fileBase}-daysheet-${filterDate}.xlsx`);
+    } catch {
+      toast.error(t("exportError"));
+    }
+  }
+
+  function handleDaySheetHtml(filterDate: string) {
+    try {
+      const data = getDaySheetData(filterDate);
+      const html = generateDaySheetHtml(data, daySheetColumnLabels, locale);
+      const blob = new Blob([html], { type: "text/html;charset=utf-8" });
+      downloadBlob(blob, `${fileBase}-daysheet-${filterDate}.html`);
+    } catch {
+      toast.error(t("exportError"));
+    }
+  }
+
+  function handleDaySheetMarkdown(filterDate: string) {
+    try {
+      const data = getDaySheetData(filterDate);
+      const md = generateDaySheetMarkdown(data, daySheetColumnLabels);
+      const blob = new Blob([md], { type: "text/markdown;charset=utf-8" });
+      downloadBlob(blob, `${fileBase}-daysheet-${filterDate}.md`);
+    } catch {
+      toast.error(t("exportError"));
+    }
+  }
+
+  async function handleDaySheetCopyMarkdown(filterDate: string) {
+    try {
+      const data = getDaySheetData(filterDate);
+      const md = generateDaySheetMarkdown(data, daySheetColumnLabels);
+      const ok = await copyToClipboard(md);
+      if (ok) {
+        setCopiedMd(true);
+        toast.success(t("copied"));
+        setTimeout(() => setCopiedMd(false), 2000);
+      } else {
+        toast.error(t("copyFailed"));
+      }
+    } catch {
+      toast.error(t("copyFailed"));
+    }
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -249,6 +336,47 @@ export function ExportDropdown({
           )}
           {copiedMd ? t("copied") : t("copyMarkdown")}
         </DropdownMenuItem>
+        {target === "assignments" && uniqueDates.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>{t("daySheet")}</DropdownMenuLabel>
+            {uniqueDates.map((date) => (
+              <DropdownMenuSub key={date.iso}>
+                <DropdownMenuSubTrigger>
+                  <CalendarDays className="mr-2 h-4 w-4" />
+                  {date.label}
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent>
+                  <DropdownMenuItem
+                    onClick={() => handleDaySheetXlsx(date.iso)}
+                  >
+                    <FileSpreadsheet className="mr-2 h-4 w-4" />
+                    {t("exportXlsx")}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => handleDaySheetHtml(date.iso)}
+                  >
+                    <Code className="mr-2 h-4 w-4" />
+                    {t("exportHtml")}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => handleDaySheetMarkdown(date.iso)}
+                  >
+                    <FileText className="mr-2 h-4 w-4" />
+                    {t("exportMarkdown")}
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={() => handleDaySheetCopyMarkdown(date.iso)}
+                  >
+                    <Copy className="mr-2 h-4 w-4" />
+                    {t("copyMarkdown")}
+                  </DropdownMenuItem>
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            ))}
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/components/polls/export-dropdown.tsx
+++ b/components/polls/export-dropdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   Download,
   FileSpreadsheet,
@@ -79,13 +79,15 @@ export function ExportDropdown({
   const locale = useLocale();
   const [copiedMd, setCopiedMd] = useState(false);
 
-  function formatDate(iso: string): string {
-    return format.dateTime(new Date(iso), {
-      weekday: "short",
-      day: "numeric",
-      month: "short",
-    });
-  }
+  const formatDate = useCallback(
+    (iso: string): string =>
+      format.dateTime(new Date(iso), {
+        weekday: "short",
+        day: "numeric",
+        month: "short",
+      }),
+    [format],
+  );
 
   function formatTime(iso: string): string {
     return format.dateTime(new Date(iso), {
@@ -100,8 +102,7 @@ export function ExportDropdown({
   const uniqueDates = useMemo(() => {
     const dates = [...new Set(matches.map((m) => m.date))].sort();
     return dates.map((d) => ({ iso: d, label: formatDate(d) }));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [matches]);
+  }, [matches, formatDate]);
 
   const target: ExportTarget | null =
     activeTab === "responses"
@@ -251,54 +252,41 @@ export function ExportDropdown({
     }
   }
 
-  async function handleDaySheetXlsx(filterDate: string) {
-    try {
-      const { generateDaySheetXlsx } =
-        await import("@/lib/export/generators/xlsx");
-      const data = getDaySheetData(filterDate);
-      const blob = await generateDaySheetXlsx(data, daySheetColumnLabels);
-      downloadBlob(blob, `${fileBase}-daysheet-${filterDate}.xlsx`);
-    } catch {
-      toast.error(t("exportError"));
-    }
-  }
-
-  function handleDaySheetHtml(filterDate: string) {
+  async function handleDaySheet(
+    exportFormat: "xlsx" | "html" | "markdown" | "copy",
+    filterDate: string,
+  ) {
     try {
       const data = getDaySheetData(filterDate);
-      const html = generateDaySheetHtml(data, daySheetColumnLabels, locale);
-      const blob = new Blob([html], { type: "text/html;charset=utf-8" });
-      downloadBlob(blob, `${fileBase}-daysheet-${filterDate}.html`);
-    } catch {
-      toast.error(t("exportError"));
-    }
-  }
-
-  function handleDaySheetMarkdown(filterDate: string) {
-    try {
-      const data = getDaySheetData(filterDate);
-      const md = generateDaySheetMarkdown(data, daySheetColumnLabels);
-      const blob = new Blob([md], { type: "text/markdown;charset=utf-8" });
-      downloadBlob(blob, `${fileBase}-daysheet-${filterDate}.md`);
-    } catch {
-      toast.error(t("exportError"));
-    }
-  }
-
-  async function handleDaySheetCopyMarkdown(filterDate: string) {
-    try {
-      const data = getDaySheetData(filterDate);
-      const md = generateDaySheetMarkdown(data, daySheetColumnLabels);
-      const ok = await copyToClipboard(md);
-      if (ok) {
-        setCopiedMd(true);
-        toast.success(t("copied"));
-        setTimeout(() => setCopiedMd(false), 2000);
+      if (exportFormat === "xlsx") {
+        const { generateDaySheetXlsx } =
+          await import("@/lib/export/generators/xlsx");
+        const blob = await generateDaySheetXlsx(data, daySheetColumnLabels);
+        downloadBlob(blob, `${fileBase}-daysheet-${filterDate}.xlsx`);
+      } else if (exportFormat === "html") {
+        const html = generateDaySheetHtml(data, daySheetColumnLabels, locale);
+        const blob = new Blob([html], { type: "text/html;charset=utf-8" });
+        downloadBlob(blob, `${fileBase}-daysheet-${filterDate}.html`);
       } else {
-        toast.error(t("copyFailed"));
+        const md = generateDaySheetMarkdown(data, daySheetColumnLabels);
+        if (exportFormat === "copy") {
+          const ok = await copyToClipboard(md);
+          if (ok) {
+            setCopiedMd(true);
+            toast.success(t("copied"));
+            setTimeout(() => setCopiedMd(false), 2000);
+          } else {
+            toast.error(t("copyFailed"));
+          }
+        } else {
+          const blob = new Blob([md], {
+            type: "text/markdown;charset=utf-8",
+          });
+          downloadBlob(blob, `${fileBase}-daysheet-${filterDate}.md`);
+        }
       }
     } catch {
-      toast.error(t("copyFailed"));
+      toast.error(t("exportError"));
     }
   }
 
@@ -348,26 +336,26 @@ export function ExportDropdown({
                 </DropdownMenuSubTrigger>
                 <DropdownMenuSubContent>
                   <DropdownMenuItem
-                    onClick={() => handleDaySheetXlsx(date.iso)}
+                    onClick={() => handleDaySheet("xlsx", date.iso)}
                   >
                     <FileSpreadsheet className="mr-2 h-4 w-4" />
                     {t("exportXlsx")}
                   </DropdownMenuItem>
                   <DropdownMenuItem
-                    onClick={() => handleDaySheetHtml(date.iso)}
+                    onClick={() => handleDaySheet("html", date.iso)}
                   >
                     <Code className="mr-2 h-4 w-4" />
                     {t("exportHtml")}
                   </DropdownMenuItem>
                   <DropdownMenuItem
-                    onClick={() => handleDaySheetMarkdown(date.iso)}
+                    onClick={() => handleDaySheet("markdown", date.iso)}
                   >
                     <FileText className="mr-2 h-4 w-4" />
                     {t("exportMarkdown")}
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
-                    onClick={() => handleDaySheetCopyMarkdown(date.iso)}
+                    onClick={() => handleDaySheet("copy", date.iso)}
                   >
                     <Copy className="mr-2 h-4 w-4" />
                     {t("copyMarkdown")}

--- a/e2e/day-sheet-export.spec.ts
+++ b/e2e/day-sheet-export.spec.ts
@@ -1,0 +1,301 @@
+import { test, expect } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+import { loadEnvConfig } from "@next/env";
+
+// Load env so Supabase vars are available
+loadEnvConfig(process.cwd());
+
+function getServiceClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+  return createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+test.describe("Day sheet export", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const uniqueId = Date.now();
+  const pollTitle = `E2E Day Sheet ${uniqueId}`;
+  let pollUrl = "";
+  let pollId = "";
+  let orgId = "";
+  let matchIds: string[] = [];
+  let setupDone = false;
+
+  test("seed matches, poll and assignments via API", async () => {
+    const supabase = getServiceClient();
+
+    // Find the E2E test user and their organization
+    const {
+      data: { users },
+    } = await supabase.auth.admin.listUsers();
+    const authUser = users.find(
+      (u) => u.email === "e2e-test@fluitplanner.test",
+    );
+    expect(authUser).toBeTruthy();
+    const userId = authUser!.id;
+
+    const { data: membership } = await supabase
+      .from("organization_members")
+      .select("organization_id")
+      .eq("user_id", userId)
+      .single();
+
+    expect(membership).toBeTruthy();
+    orgId = membership!.organization_id;
+
+    // Create 3 test matches for today
+    const today = new Date().toISOString().slice(0, 10);
+    const matchInserts = [
+      {
+        date: today,
+        start_time: `${today}T10:00:00`,
+        home_team: `E2E Home A ${uniqueId}`,
+        away_team: `E2E Away A ${uniqueId}`,
+        venue: "Test Venue",
+        field: "Field 1",
+        competition: "Test League",
+        organization_id: orgId,
+        created_by: userId,
+      },
+      {
+        date: today,
+        start_time: `${today}T12:00:00`,
+        home_team: `E2E Home B ${uniqueId}`,
+        away_team: `E2E Away B ${uniqueId}`,
+        venue: "Test Venue",
+        field: "Field 2",
+        competition: "Test League",
+        organization_id: orgId,
+        created_by: userId,
+      },
+      {
+        date: today,
+        start_time: `${today}T14:00:00`,
+        home_team: `E2E Home C ${uniqueId}`,
+        away_team: `E2E Away C ${uniqueId}`,
+        venue: "Test Venue",
+        field: "Field 1",
+        competition: "Test League",
+        organization_id: orgId,
+        created_by: userId,
+      },
+    ];
+
+    const { data: matches, error: mErr } = await supabase
+      .from("matches")
+      .insert(matchInserts)
+      .select("id");
+
+    expect(mErr).toBeNull();
+    expect(matches).toBeTruthy();
+    matchIds = matches!.map((m) => m.id);
+
+    // Create poll (token is required, generate a random one)
+    const token = `e2e-${uniqueId}-${Math.random().toString(36).slice(2, 10)}`;
+    const { data: poll, error: pErr } = await supabase
+      .from("polls")
+      .insert({
+        title: pollTitle,
+        token,
+        status: "open",
+        organization_id: orgId,
+        created_by: userId,
+      })
+      .select("id")
+      .single();
+
+    expect(pErr).toBeNull();
+    expect(poll).toBeTruthy();
+    pollId = poll!.id;
+
+    // Link matches to poll
+    const pollMatches = matchIds.map((matchId) => ({
+      poll_id: pollId,
+      match_id: matchId,
+    }));
+    const { error: pmErr } = await supabase
+      .from("poll_matches")
+      .insert(pollMatches);
+    expect(pmErr).toBeNull();
+
+    // Get or create 2 umpires
+    let { data: orgUmpires } = await supabase
+      .from("organization_umpires")
+      .select("umpire_id, umpires(id, name)")
+      .eq("organization_id", orgId)
+      .limit(2);
+
+    if (!orgUmpires || orgUmpires.length < 2) {
+      const names = [`E2E Umpire A ${uniqueId}`, `E2E Umpire B ${uniqueId}`];
+      for (const name of names) {
+        const { data: umpire } = await supabase
+          .from("umpires")
+          .insert({ name, email: `${name.replace(/\s/g, ".")}@test.local` })
+          .select("id")
+          .single();
+        if (umpire) {
+          await supabase
+            .from("organization_umpires")
+            .insert({ organization_id: orgId, umpire_id: umpire.id });
+        }
+      }
+      const result = await supabase
+        .from("organization_umpires")
+        .select("umpire_id, umpires(id, name)")
+        .eq("organization_id", orgId)
+        .limit(2);
+      orgUmpires = result.data;
+    }
+
+    expect(orgUmpires!.length).toBeGreaterThanOrEqual(2);
+    const umpireIds = orgUmpires!.map((ou) => ou.umpire_id);
+
+    // Create assignments
+    const assignments = matchIds.flatMap((matchId) =>
+      umpireIds.slice(0, 2).map((umpireId) => ({
+        poll_id: pollId,
+        match_id: matchId,
+        umpire_id: umpireId,
+        organization_id: orgId,
+      })),
+    );
+
+    const { error: aErr } = await supabase
+      .from("assignments")
+      .insert(assignments);
+    expect(aErr).toBeNull();
+
+    pollUrl = `/protected/polls/${pollId}`;
+    setupDone = true;
+  });
+
+  test("assignments tab shows export dropdown with day sheet section", async ({
+    page,
+  }) => {
+    test.skip(!setupDone, "Setup failed");
+
+    await page.goto(pollUrl);
+
+    // Switch to assignments tab
+    const assignmentsTab = page.getByRole("tab", { name: /assignments/i });
+    await expect(assignmentsTab).toBeVisible({ timeout: 10000 });
+    await assignmentsTab.click();
+
+    // Open the export dropdown
+    const exportButton = page.getByRole("button", { name: /export/i });
+    await expect(exportButton).toBeVisible();
+    await exportButton.click();
+
+    // Verify "Day sheet" label appears in the dropdown
+    await expect(page.getByText("Day sheet", { exact: true })).toBeVisible();
+  });
+
+  test("day sheet sub-menu shows date entries with format options", async ({
+    page,
+  }) => {
+    test.skip(!setupDone, "Setup failed");
+
+    await page.goto(pollUrl);
+    await page.getByRole("tab", { name: /assignments/i }).click();
+    await page.getByRole("button", { name: /export/i }).click();
+    await expect(page.getByText("Day sheet", { exact: true })).toBeVisible();
+
+    // Hover over the first date sub-trigger
+    const subTriggers = page.locator("[role='menuitem'][data-state]");
+    const subTriggerCount = await subTriggers.count();
+    expect(subTriggerCount).toBeGreaterThan(0);
+    await subTriggers.first().hover();
+
+    // Verify sub-menu shows all 4 export format options
+    const subMenu = page.locator("[role='menu']").last();
+    await expect(subMenu.getByText("Excel (.xlsx)")).toBeVisible();
+    await expect(subMenu.getByText("HTML (.html)")).toBeVisible();
+    await expect(subMenu.getByText("Markdown (.md)")).toBeVisible();
+    await expect(subMenu.getByText("Copy as Markdown")).toBeVisible();
+  });
+
+  test("day sheet markdown export downloads a file with umpire names", async ({
+    page,
+  }) => {
+    test.skip(!setupDone, "Setup failed");
+
+    await page.goto(pollUrl);
+    await page.getByRole("tab", { name: /assignments/i }).click();
+    await page.getByRole("button", { name: /export/i }).click();
+    await expect(page.getByText("Day sheet", { exact: true })).toBeVisible();
+
+    const subTriggers = page.locator("[role='menuitem'][data-state]");
+    await subTriggers.first().hover();
+
+    // Wait for sub-menu to fully render
+    await page.waitForTimeout(300);
+
+    // The sub-menu is the last [role='menu'] portal
+    const subMenu = page.locator("[role='menu']").last();
+    const mdItem = subMenu.getByText("Markdown (.md)");
+    await expect(mdItem).toBeVisible();
+
+    // Hover over the item first to ensure focus stays in sub-menu
+    await mdItem.hover();
+
+    const downloadPromise = page.waitForEvent("download");
+    await mdItem.click({ force: true });
+
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/daysheet.*\.md$/);
+
+    // Read the downloaded file and verify contents
+    const stream = await download.createReadStream();
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(Buffer.from(chunk));
+    }
+    const content = Buffer.concat(chunks).toString("utf-8");
+
+    // Should contain the poll title and a markdown table
+    expect(content).toContain(pollTitle);
+    expect(content).toContain("##"); // date heading
+    expect(content).toContain("|"); // table rows
+    expect(content).toContain("Umpire"); // column header
+  });
+
+  test("day sheet xlsx export downloads a file", async ({ page }) => {
+    test.skip(!setupDone, "Setup failed");
+
+    await page.goto(pollUrl);
+    await page.getByRole("tab", { name: /assignments/i }).click();
+    await page.getByRole("button", { name: /export/i }).click();
+
+    const subTriggers = page.locator("[role='menuitem'][data-state]");
+    await subTriggers.first().hover();
+    await page.waitForTimeout(300);
+
+    const subMenu = page.locator("[role='menu']").last();
+    const xlsxItem = subMenu.getByText("Excel (.xlsx)");
+    await expect(xlsxItem).toBeVisible();
+    await xlsxItem.hover();
+
+    const downloadPromise = page.waitForEvent("download");
+    await xlsxItem.click({ force: true });
+
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/daysheet.*\.xlsx$/);
+  });
+
+  test("cleanup: delete test data", async () => {
+    test.skip(!setupDone, "Setup failed");
+
+    const supabase = getServiceClient();
+
+    // Delete in dependency order
+    await supabase.from("assignments").delete().eq("poll_id", pollId);
+    await supabase.from("poll_matches").delete().eq("poll_id", pollId);
+    await supabase.from("polls").delete().eq("id", pollId);
+    for (const matchId of matchIds) {
+      await supabase.from("matches").delete().eq("id", matchId);
+    }
+  });
+});

--- a/lib/export/generators/html.ts
+++ b/lib/export/generators/html.ts
@@ -1,6 +1,7 @@
 import type {
   ResponseExportData,
   AssignmentExportData,
+  DaySheetExportData,
   ResponseCell,
 } from "../prepare-export-data";
 
@@ -214,6 +215,61 @@ export function generateAssignmentHtml(
   return wrapHtml(
     data.pollTitle,
     `<h1>${escapeHtml(data.pollTitle)}</h1>\n<table>\n<thead>\n${headerRow}\n</thead>\n<tbody>\n${bodyRows}\n</tbody>\n</table>`,
+    locale,
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Day sheet export                                                   */
+/* ------------------------------------------------------------------ */
+
+export function generateDaySheetHtml(
+  data: DaySheetExportData,
+  columnLabels: {
+    time: string;
+    match: string;
+    field: string;
+    umpire1: string;
+    umpire2: string;
+    noData?: string;
+  },
+  locale = "en",
+): string {
+  if (data.rows.length === 0) {
+    const emptyMsg = columnLabels.noData ?? "No matches.";
+    return wrapHtml(
+      data.pollTitle,
+      `<h1>${escapeHtml(data.pollTitle)}</h1><p>${escapeHtml(emptyMsg)}</p>`,
+      locale,
+    );
+  }
+
+  const headers = [
+    columnLabels.time,
+    columnLabels.match,
+    columnLabels.field,
+    columnLabels.umpire1,
+    columnLabels.umpire2,
+  ];
+
+  const headerRow = `<tr>${headers.map((h) => `<th>${escapeHtml(h)}</th>`).join("")}</tr>`;
+
+  const bodyRowsHtml = data.rows
+    .map(
+      (row) =>
+        `<tr>
+<td>${escapeHtml(row.time)}</td>
+<td>${escapeHtml(row.match)}</td>
+<td>${escapeHtml(row.field)}</td>
+<td>${escapeHtml(row.umpire1)}</td>
+<td>${escapeHtml(row.umpire2)}</td>
+</tr>`,
+    )
+    .join("\n");
+
+  return wrapHtml(
+    data.pollTitle,
+    `<h1>${escapeHtml(data.pollTitle)}</h1>\n<h2>${escapeHtml(data.date)}</h2>\n<table>\n<thead>\n${headerRow}\n</thead>\n<tbody>\n${bodyRowsHtml}\n</tbody>\n</table>`,
     locale,
   );
 }

--- a/lib/export/generators/html.ts
+++ b/lib/export/generators/html.ts
@@ -2,6 +2,7 @@ import type {
   ResponseExportData,
   AssignmentExportData,
   DaySheetExportData,
+  DaySheetColumnLabels,
   ResponseCell,
 } from "../prepare-export-data";
 
@@ -225,14 +226,7 @@ export function generateAssignmentHtml(
 
 export function generateDaySheetHtml(
   data: DaySheetExportData,
-  columnLabels: {
-    time: string;
-    match: string;
-    field: string;
-    umpire1: string;
-    umpire2: string;
-    noData?: string;
-  },
+  columnLabels: DaySheetColumnLabels,
   locale = "en",
 ): string {
   if (data.rows.length === 0) {

--- a/lib/export/generators/markdown.ts
+++ b/lib/export/generators/markdown.ts
@@ -1,6 +1,7 @@
 import type {
   ResponseExportData,
   AssignmentExportData,
+  DaySheetExportData,
   ResponseCell,
 } from "../prepare-export-data";
 
@@ -141,6 +142,64 @@ export function generateAssignmentMarkdown(
   // Separator
   lines.push(`| ${colWidths.map((w) => "-".repeat(w)).join(" | ")} |`);
   // Data rows
+  for (const row of bodyRows) {
+    lines.push(
+      `| ${row.map((cell, i) => padCell(cell, colWidths[i])).join(" | ")} |`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Day sheet export                                                   */
+/* ------------------------------------------------------------------ */
+
+export function generateDaySheetMarkdown(
+  data: DaySheetExportData,
+  columnLabels: {
+    time: string;
+    match: string;
+    field: string;
+    umpire1: string;
+    umpire2: string;
+  },
+): string {
+  const lines: string[] = [];
+
+  lines.push(`# ${data.pollTitle}`);
+  lines.push("");
+  lines.push(`## ${data.date}`);
+  lines.push("");
+
+  if (data.rows.length === 0) {
+    return lines.join("\n");
+  }
+
+  const colHeaders = [
+    escapeMdCell(columnLabels.time),
+    escapeMdCell(columnLabels.match),
+    escapeMdCell(columnLabels.field),
+    escapeMdCell(columnLabels.umpire1),
+    escapeMdCell(columnLabels.umpire2),
+  ];
+
+  const bodyRows = data.rows.map((row) => [
+    escapeMdCell(row.time),
+    escapeMdCell(row.match),
+    escapeMdCell(row.field),
+    escapeMdCell(row.umpire1),
+    escapeMdCell(row.umpire2),
+  ]);
+
+  const colWidths = colHeaders.map((h, i) =>
+    Math.max(h.length, ...bodyRows.map((row) => (row[i] ?? "").length), 3),
+  );
+
+  lines.push(
+    `| ${colHeaders.map((h, i) => padCell(h, colWidths[i])).join(" | ")} |`,
+  );
+  lines.push(`| ${colWidths.map((w) => "-".repeat(w)).join(" | ")} |`);
   for (const row of bodyRows) {
     lines.push(
       `| ${row.map((cell, i) => padCell(cell, colWidths[i])).join(" | ")} |`,

--- a/lib/export/generators/markdown.ts
+++ b/lib/export/generators/markdown.ts
@@ -2,6 +2,7 @@ import type {
   ResponseExportData,
   AssignmentExportData,
   DaySheetExportData,
+  DaySheetColumnLabels,
   ResponseCell,
 } from "../prepare-export-data";
 
@@ -17,6 +18,26 @@ function escapeMdCell(value: string): string {
 
 function padCell(value: string, width: number): string {
   return value.padEnd(width);
+}
+
+function renderMarkdownTable(
+  colHeaders: string[],
+  bodyRows: string[][],
+): string[] {
+  const colWidths = colHeaders.map((h, i) =>
+    Math.max(h.length, ...bodyRows.map((row) => (row[i] ?? "").length), 3),
+  );
+  const lines: string[] = [];
+  lines.push(
+    `| ${colHeaders.map((h, i) => padCell(h, colWidths[i])).join(" | ")} |`,
+  );
+  lines.push(`| ${colWidths.map((w) => "-".repeat(w)).join(" | ")} |`);
+  for (const row of bodyRows) {
+    lines.push(
+      `| ${row.map((cell, i) => padCell(cell, colWidths[i])).join(" | ")} |`,
+    );
+  }
+  return lines;
 }
 
 /* ------------------------------------------------------------------ */
@@ -46,27 +67,7 @@ export function generateResponseMarkdown(
     ...row.cells.map((cell) => (cell ? RESPONSE_SYMBOLS[cell] : "-")),
   ]);
 
-  // Calculate column widths
-  const colWidths = colHeaders.map((h, i) =>
-    Math.max(
-      h.length,
-      ...bodyRows.map((row) => (row[i] ?? "").length),
-      3, // minimum width for separator
-    ),
-  );
-
-  // Header row
-  lines.push(
-    `| ${colHeaders.map((h, i) => padCell(h, colWidths[i])).join(" | ")} |`,
-  );
-  // Separator row
-  lines.push(`| ${colWidths.map((w) => "-".repeat(w)).join(" | ")} |`);
-  // Data rows
-  for (const row of bodyRows) {
-    lines.push(
-      `| ${row.map((cell, i) => padCell(cell, colWidths[i])).join(" | ")} |`,
-    );
-  }
+  lines.push(...renderMarkdownTable(colHeaders, bodyRows));
 
   lines.push("");
   lines.push(
@@ -130,23 +131,7 @@ export function generateAssignmentMarkdown(
     escapeMdCell(row.assignmentCount),
   ]);
 
-  // Calculate column widths
-  const colWidths = colHeaders.map((h, i) =>
-    Math.max(h.length, ...bodyRows.map((row) => (row[i] ?? "").length), 3),
-  );
-
-  // Header row
-  lines.push(
-    `| ${colHeaders.map((h, i) => padCell(h, colWidths[i])).join(" | ")} |`,
-  );
-  // Separator
-  lines.push(`| ${colWidths.map((w) => "-".repeat(w)).join(" | ")} |`);
-  // Data rows
-  for (const row of bodyRows) {
-    lines.push(
-      `| ${row.map((cell, i) => padCell(cell, colWidths[i])).join(" | ")} |`,
-    );
-  }
+  lines.push(...renderMarkdownTable(colHeaders, bodyRows));
 
   return lines.join("\n");
 }
@@ -157,13 +142,7 @@ export function generateAssignmentMarkdown(
 
 export function generateDaySheetMarkdown(
   data: DaySheetExportData,
-  columnLabels: {
-    time: string;
-    match: string;
-    field: string;
-    umpire1: string;
-    umpire2: string;
-  },
+  columnLabels: DaySheetColumnLabels,
 ): string {
   const lines: string[] = [];
 
@@ -192,19 +171,7 @@ export function generateDaySheetMarkdown(
     escapeMdCell(row.umpire2),
   ]);
 
-  const colWidths = colHeaders.map((h, i) =>
-    Math.max(h.length, ...bodyRows.map((row) => (row[i] ?? "").length), 3),
-  );
-
-  lines.push(
-    `| ${colHeaders.map((h, i) => padCell(h, colWidths[i])).join(" | ")} |`,
-  );
-  lines.push(`| ${colWidths.map((w) => "-".repeat(w)).join(" | ")} |`);
-  for (const row of bodyRows) {
-    lines.push(
-      `| ${row.map((cell, i) => padCell(cell, colWidths[i])).join(" | ")} |`,
-    );
-  }
+  lines.push(...renderMarkdownTable(colHeaders, bodyRows));
 
   return lines.join("\n");
 }

--- a/lib/export/generators/xlsx.ts
+++ b/lib/export/generators/xlsx.ts
@@ -1,6 +1,7 @@
 import type {
   ResponseExportData,
   AssignmentExportData,
+  DaySheetExportData,
   ResponseCell,
 } from "../prepare-export-data";
 
@@ -234,6 +235,78 @@ export async function generateAssignmentXlsx(
   const colWidths = [12, 8, 20, 20, 16, 8, 16, 18, 18, 8];
   for (let i = 0; i < colWidths.length; i++) {
     sheet.getColumn(i + 1).width = colWidths[i];
+  }
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  return new Blob([buffer], {
+    type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Day sheet export                                                   */
+/* ------------------------------------------------------------------ */
+
+export async function generateDaySheetXlsx(
+  data: DaySheetExportData,
+  columnLabels: {
+    time: string;
+    match: string;
+    field: string;
+    umpire1: string;
+    umpire2: string;
+  },
+): Promise<Blob> {
+  const ExcelJS = await import("exceljs");
+  const workbook = new ExcelJS.Workbook();
+  const sheet = workbook.addWorksheet(data.pollTitle.slice(0, 31) || "Export");
+
+  const headers = [
+    columnLabels.time,
+    columnLabels.match,
+    columnLabels.field,
+    columnLabels.umpire1,
+    columnLabels.umpire2,
+  ];
+
+  // Row 1: Poll title (merged)
+  sheet.mergeCells(1, 1, 1, headers.length);
+  const titleCell = sheet.getCell(1, 1);
+  titleCell.value = data.pollTitle;
+  titleCell.font = { bold: true, size: 14 };
+
+  // Row 2: Date (merged)
+  sheet.mergeCells(2, 1, 2, headers.length);
+  const dateCell = sheet.getCell(2, 1);
+  dateCell.value = data.date;
+  dateCell.font = { bold: true, size: 12 };
+
+  // Row 3: Column headers
+  for (let i = 0; i < headers.length; i++) {
+    const cell = sheet.getCell(3, i + 1);
+    cell.value = headers[i];
+    cell.font = { bold: true };
+    cell.fill = {
+      type: "pattern",
+      pattern: "solid",
+      fgColor: { argb: "FFF9FAFB" },
+    };
+  }
+
+  // Data rows
+  for (let ri = 0; ri < data.rows.length; ri++) {
+    const row = data.rows[ri];
+    const excelRow = ri + 4;
+    const values = [row.time, row.match, row.field, row.umpire1, row.umpire2];
+    for (let ci = 0; ci < values.length; ci++) {
+      sheet.getCell(excelRow, ci + 1).value = values[ci];
+    }
+  }
+
+  // Column widths
+  const daySheetColWidths = [8, 30, 10, 18, 18];
+  for (let i = 0; i < daySheetColWidths.length; i++) {
+    sheet.getColumn(i + 1).width = daySheetColWidths[i];
   }
 
   const buffer = await workbook.xlsx.writeBuffer();

--- a/lib/export/generators/xlsx.ts
+++ b/lib/export/generators/xlsx.ts
@@ -2,6 +2,7 @@ import type {
   ResponseExportData,
   AssignmentExportData,
   DaySheetExportData,
+  DaySheetColumnLabels,
   ResponseCell,
 } from "../prepare-export-data";
 
@@ -249,13 +250,7 @@ export async function generateAssignmentXlsx(
 
 export async function generateDaySheetXlsx(
   data: DaySheetExportData,
-  columnLabels: {
-    time: string;
-    match: string;
-    field: string;
-    umpire1: string;
-    umpire2: string;
-  },
+  columnLabels: DaySheetColumnLabels,
 ): Promise<Blob> {
   const ExcelJS = await import("exceljs");
   const workbook = new ExcelJS.Workbook();

--- a/lib/export/prepare-export-data.ts
+++ b/lib/export/prepare-export-data.ts
@@ -104,6 +104,66 @@ export function prepareResponseExport(
 }
 
 /* ------------------------------------------------------------------ */
+/*  Day sheet export                                                   */
+/* ------------------------------------------------------------------ */
+
+export type DaySheetRow = {
+  time: string;
+  match: string;
+  field: string;
+  umpire1: string;
+  umpire2: string;
+};
+
+export type DaySheetExportData = {
+  pollTitle: string;
+  date: string;
+  rows: DaySheetRow[];
+};
+
+export function prepareDaySheetExport(
+  pollTitle: string,
+  matches: Match[],
+  assignments: Assignment[],
+  umpires: Umpire[],
+  formatDate: (iso: string) => string,
+  formatTime: (iso: string) => string,
+  filterDate: string,
+): DaySheetExportData {
+  const filtered = matches
+    .filter((m) => m.date === filterDate)
+    .sort((a, b) => (a.start_time ?? "").localeCompare(b.start_time ?? ""));
+
+  const umpireNameMap = new Map<string, string>();
+  for (const u of umpires) {
+    umpireNameMap.set(u.id, u.name);
+  }
+
+  const assignmentsByMatch = new Map<string, string[]>();
+  for (const a of assignments) {
+    const names = assignmentsByMatch.get(a.match_id) ?? [];
+    const name = umpireNameMap.get(a.umpire_id) ?? "";
+    names.push(name);
+    assignmentsByMatch.set(a.match_id, names);
+  }
+
+  const rows: DaySheetRow[] = filtered.map((match) => {
+    const assignedUmpires = (assignmentsByMatch.get(match.id) ?? []).sort(
+      (a, b) => a.localeCompare(b),
+    );
+    return {
+      time: match.start_time ? formatTime(match.start_time) : "",
+      match: `${match.home_team} - ${match.away_team}`,
+      field: match.field ?? "",
+      umpire1: assignedUmpires[0] ?? "",
+      umpire2: assignedUmpires[1] ?? "",
+    };
+  });
+
+  return { pollTitle, date: formatDate(filterDate), rows };
+}
+
+/* ------------------------------------------------------------------ */
 /*  Assignment export                                                  */
 /* ------------------------------------------------------------------ */
 

--- a/lib/export/prepare-export-data.ts
+++ b/lib/export/prepare-export-data.ts
@@ -47,6 +47,60 @@ export type AssignmentExportData = {
   rows: AssignmentExportRow[];
 };
 
+export type DaySheetRow = {
+  time: string;
+  match: string;
+  field: string;
+  umpire1: string;
+  umpire2: string;
+};
+
+export type DaySheetExportData = {
+  pollTitle: string;
+  date: string;
+  rows: DaySheetRow[];
+};
+
+export type DaySheetColumnLabels = {
+  time: string;
+  match: string;
+  field: string;
+  umpire1: string;
+  umpire2: string;
+  noData?: string;
+};
+
+/* ------------------------------------------------------------------ */
+/*  Shared helpers                                                     */
+/* ------------------------------------------------------------------ */
+
+function buildAssignmentsByMatch(
+  assignments: Assignment[],
+  umpires: Umpire[],
+): Map<string, string[]> {
+  const umpireNameMap = new Map<string, string>();
+  for (const u of umpires) {
+    umpireNameMap.set(u.id, u.name);
+  }
+
+  const byMatch = new Map<string, string[]>();
+  for (const a of assignments) {
+    const names = byMatch.get(a.match_id) ?? [];
+    names.push(umpireNameMap.get(a.umpire_id) ?? "");
+    byMatch.set(a.match_id, names);
+  }
+  return byMatch;
+}
+
+function getSortedUmpires(
+  assignmentsByMatch: Map<string, string[]>,
+  matchId: string,
+): string[] {
+  return (assignmentsByMatch.get(matchId) ?? []).sort((a, b) =>
+    a.localeCompare(b),
+  );
+}
+
 /* ------------------------------------------------------------------ */
 /*  Response export                                                    */
 /* ------------------------------------------------------------------ */
@@ -107,20 +161,6 @@ export function prepareResponseExport(
 /*  Day sheet export                                                   */
 /* ------------------------------------------------------------------ */
 
-export type DaySheetRow = {
-  time: string;
-  match: string;
-  field: string;
-  umpire1: string;
-  umpire2: string;
-};
-
-export type DaySheetExportData = {
-  pollTitle: string;
-  date: string;
-  rows: DaySheetRow[];
-};
-
 export function prepareDaySheetExport(
   pollTitle: string,
   matches: Match[],
@@ -134,23 +174,10 @@ export function prepareDaySheetExport(
     .filter((m) => m.date === filterDate)
     .sort((a, b) => (a.start_time ?? "").localeCompare(b.start_time ?? ""));
 
-  const umpireNameMap = new Map<string, string>();
-  for (const u of umpires) {
-    umpireNameMap.set(u.id, u.name);
-  }
-
-  const assignmentsByMatch = new Map<string, string[]>();
-  for (const a of assignments) {
-    const names = assignmentsByMatch.get(a.match_id) ?? [];
-    const name = umpireNameMap.get(a.umpire_id) ?? "";
-    names.push(name);
-    assignmentsByMatch.set(a.match_id, names);
-  }
+  const assignmentsByMatch = buildAssignmentsByMatch(assignments, umpires);
 
   const rows: DaySheetRow[] = filtered.map((match) => {
-    const assignedUmpires = (assignmentsByMatch.get(match.id) ?? []).sort(
-      (a, b) => a.localeCompare(b),
-    );
+    const assignedUmpires = getSortedUmpires(assignmentsByMatch, match.id);
     return {
       time: match.start_time ? formatTime(match.start_time) : "",
       match: `${match.home_team} - ${match.away_team}`,
@@ -181,25 +208,10 @@ export function prepareAssignmentExport(
     return (a.start_time ?? "").localeCompare(b.start_time ?? "");
   });
 
-  // Build umpire name lookup
-  const umpireNameMap = new Map<string, string>();
-  for (const u of umpires) {
-    umpireNameMap.set(u.id, u.name);
-  }
-
-  // Group assignments by match_id
-  const assignmentsByMatch = new Map<string, string[]>();
-  for (const a of assignments) {
-    const names = assignmentsByMatch.get(a.match_id) ?? [];
-    const name = umpireNameMap.get(a.umpire_id) ?? "";
-    names.push(name);
-    assignmentsByMatch.set(a.match_id, names);
-  }
+  const assignmentsByMatch = buildAssignmentsByMatch(assignments, umpires);
 
   const rows: AssignmentExportRow[] = sorted.map((match) => {
-    const assignedUmpires = (assignmentsByMatch.get(match.id) ?? []).sort(
-      (a, b) => a.localeCompare(b),
-    );
+    const assignedUmpires = getSortedUmpires(assignmentsByMatch, match.id);
     return {
       date: formatDate(match.date),
       time: match.start_time ? formatTime(match.start_time) : "",

--- a/messages/en.json
+++ b/messages/en.json
@@ -267,7 +267,9 @@
     "exportCount": "Count",
     "exportError": "Export failed. Please try again.",
     "copyFailed": "Failed to copy to clipboard.",
-    "noDataToExport": "No data to export."
+    "noDataToExport": "No data to export.",
+    "daySheet": "Day sheet",
+    "daySheetMatch": "Match"
   },
   "pollResponse": {
     "loadingPoll": "Loading poll...",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -268,7 +268,7 @@
     "exportError": "Exporteren mislukt. Probeer het opnieuw.",
     "copyFailed": "Kopiëren naar klembord mislukt.",
     "noDataToExport": "Geen gegevens om te exporteren.",
-    "daySheet": "Dagblad",
+    "daySheet": "Dagoverzicht",
     "daySheetMatch": "Wedstrijd"
   },
   "pollResponse": {

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -267,7 +267,9 @@
     "exportCount": "Aantal",
     "exportError": "Exporteren mislukt. Probeer het opnieuw.",
     "copyFailed": "Kopiëren naar klembord mislukt.",
-    "noDataToExport": "Geen gegevens om te exporteren."
+    "noDataToExport": "Geen gegevens om te exporteren.",
+    "daySheet": "Dagblad",
+    "daySheetMatch": "Wedstrijd"
   },
   "pollResponse": {
     "loadingPoll": "Peiling laden...",

--- a/showboat-day-sheet-export.md
+++ b/showboat-day-sheet-export.md
@@ -1,0 +1,38 @@
+# Day Sheet Export Feature Implementation
+
+_2026-03-01T18:39:12Z by Showboat 0.6.1_
+
+<!-- showboat-id: 1bfd9ce1-0164-4281-af1c-8de121e4c811 -->
+
+Implementing a simplified 'day sheet' export for the poll detail page. The day sheet shows matches for a single date with columns: Time | Match (Home - Away) | Field | Umpire 1 | Umpire 2. Available in all export formats (XLSX, HTML, Markdown, clipboard). Triggered from the assignments tab export dropdown, with one entry per date in the poll.
+
+## Implementation Complete
+
+### Files modified:
+
+- **lib/export/prepare-export-data.ts** — Added `DaySheetRow`, `DaySheetExportData` types and `prepareDaySheetExport()` function
+- **lib/export/generators/xlsx.ts** — Added `generateDaySheetXlsx()`
+- **lib/export/generators/html.ts** — Added `generateDaySheetHtml()`
+- **lib/export/generators/markdown.ts** — Added `generateDaySheetMarkdown()`
+- **components/polls/export-dropdown.tsx** — Added day sheet sub-menus per date with all 4 export formats
+- **messages/en.json** — Added `daySheet` and `daySheetMatch` keys
+- **messages/nl.json** — Added `daySheet` and `daySheetMatch` keys
+- ****tests**/lib/export/prepare-export-data.test.ts** — Added 8 tests for `prepareDaySheetExport`
+
+```bash
+npm run type-check 2>&1 && echo '---' && npx eslint components/polls/export-dropdown.tsx lib/export/ __tests__/lib/export/ 2>&1 && echo '---' && npm test 2>&1 | tail -5
+```
+
+```output
+
+> fluitplanner@2.7.0 type-check
+> tsc --noEmit
+
+---
+---
+[2m Test Files [22m [1m[32m46 passed[39m[22m[90m (46)[39m
+[2m      Tests [22m [1m[32m357 passed[39m[22m[90m (357)[39m
+[2m   Start at [22m 19:46:44
+[2m   Duration [22m 5.92s[2m (transform 1.81s, setup 2.31s, import 13.32s, tests 12.06s, environment 16.36s)[22m
+
+```

--- a/showboat-day-sheet-export.md
+++ b/showboat-day-sheet-export.md
@@ -17,7 +17,7 @@ Implementing a simplified 'day sheet' export for the poll detail page. The day s
 - **components/polls/export-dropdown.tsx** — Added day sheet sub-menus per date with all 4 export formats
 - **messages/en.json** — Added `daySheet` and `daySheetMatch` keys
 - **messages/nl.json** — Added `daySheet` and `daySheetMatch` keys
-- ****tests**/lib/export/prepare-export-data.test.ts** — Added 8 tests for `prepareDaySheetExport`
+- \***\*tests**/lib/export/prepare-export-data.test.ts\*\* — Added 8 tests for `prepareDaySheetExport`
 
 ```bash
 npm run type-check 2>&1 && echo '---' && npx eslint components/polls/export-dropdown.tsx lib/export/ __tests__/lib/export/ 2>&1 && echo '---' && npm test 2>&1 | tail -5


### PR DESCRIPTION
## Summary
- Adds a **Day sheet** export to the poll detail page (assignments tab) — a simplified, per-date match overview with columns: **Time | Match | Field | Umpire 1 | Umpire 2**
- Each unique date in the poll gets a sub-menu with all export formats: XLSX, HTML, Markdown, and clipboard copy
- Extracts shared helpers (`buildAssignmentsByMatch`, `getSortedUmpires`, `renderMarkdownTable`) to reduce duplication across existing and new export code
- Exports a shared `DaySheetColumnLabels` type used by all three generators
- Fixes a stale-closure bug in the `useMemo` for unique dates (missing `formatDate` dep)

## Test plan
- [ ] Navigate to a poll detail page with assigned umpires
- [ ] Switch to the assignments tab and open the export dropdown
- [ ] Verify "Day sheet" section appears with one entry per date
- [ ] Export each format (XLSX, HTML, Markdown) and verify only matches for the selected date appear with the correct 5 columns
- [ ] Copy markdown to clipboard and verify content
- [ ] Switch language (EN ↔ NL) and verify date labels update correctly
- [ ] Run existing tests: `npm test` (357 passing)
- [ ] Run type-check: `npm run type-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Day-sheet export on the Assignments tab with per-date sub-menu; export as XLSX, HTML, Markdown or copy-to-clipboard, showing formatted time, match, field and umpire columns.

* **Tests**
  * Added unit and end-to-end tests validating day-sheet data preparation, filtering, sorting, exports and empty-state handling.

* **Documentation**
  * Added guide describing day-sheet export usage and formats.

* **Chores**
  * Added English and Dutch translations for day-sheet labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->