### PR TITLE
fix: resolve metadata URLs against production domain, not VERCEL_URL

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,12 +7,20 @@ import { getLocale, getMessages } from "next-intl/server";
 import { LocaleDetector } from "@/components/locale-detector";
 import "./globals.css";
 
-const defaultUrl = process.env.VERCEL_URL
-  ? `https://${process.env.VERCEL_URL}`
-  : "http://localhost:3000";
+// Prefer the production custom domain so resolved metadata URLs (e.g. og:image)
+// point somewhere crawlers can actually reach — VERCEL_URL is the immutable
+// per-deployment alias, which is gated by Vercel's deployment protection.
+const rawSiteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ??
+  (process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : "http://localhost:3000");
+const siteUrl = rawSiteUrl.startsWith("http")
+  ? rawSiteUrl
+  : `https://${rawSiteUrl}`;
 
 export const metadata: Metadata = {
-  metadataBase: new URL(defaultUrl),
+  metadataBase: new URL(siteUrl),
   title: "Fluitplanner",
   description: "Field hockey umpire availability and match assignment",
 };


### PR DESCRIPTION
## Summary
- Root cause of "WhatsApp preview shows no image" (reported after #118 merged): `app/layout.tsx` built `metadataBase` from `process.env.VERCEL_URL`, which is the immutable per-deployment alias (e.g. `fluitplanner-<hash>-<team>.vercel.app`), not the production custom domain. Confirmed in prod: `og:image` was resolving to `https://fluitplanner-m54ezbpyj-okke-suurenbroeks-projects.vercel.app/...` instead of `https://www.fluiten.org/...`.
- That deployment alias is gated by Vercel's deployment protection, so WhatsApp's link-preview crawler can't fetch the image (title/description still show because those come from the HTML page itself, fetched via the real `fluiten.org` URL the user shares — only the *image* URL was wrong). iMessage's own preview crawler apparently tolerates or bypasses this differently, which is why it "worked" there.
- Now prefers `NEXT_PUBLIC_SITE_URL`, matching the fallback order already used for magic links in `lib/actions/verification.ts`. Confirmed `NEXT_PUBLIC_SITE_URL` is already set for the Production environment on Vercel (`vercel env ls production`).

## Test plan
- [x] `npm run build`, `npm run lint`, `npm run type-check`, `npm run format:check` all pass
- [x] `npm test` — 446/446 passing
- [x] Verified locally: with `NEXT_PUBLIC_SITE_URL` set, resolved `og:image` now uses that base instead of `VERCEL_URL`
- [x] Verified `NEXT_PUBLIC_SITE_URL` is configured for Production on Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011of3M8LwP3GRwu4i5wJZhR