### PR TITLE
feat: default assignment grid to umpire rows / match columns

### DIFF
--- a/components/polls/poll-detail-client.tsx
+++ b/components/polls/poll-detail-client.tsx
@@ -67,7 +67,7 @@ export function PollDetailClient({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState("matches");
-  const [transposed, setTransposed] = useState(false);
+  const [transposed, setTransposed] = useState(true);
   const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined);
   const [liveAssignments, setLiveAssignments] = useState<Assignment[]>(
     initialPoll.assignments,


### PR DESCRIPTION
## Summary

The assignments tab opened with matches on rows and umpires on columns, which meant reaching for the swap-axes button on nearly every visit. It now starts in the transposed orientation — umpires down the left, matches across the top, grouped by date. The swap-axes button still toggles back.

One-line change: `components/polls/poll-detail-client.tsx:70`, `useState(false)` → `useState(true)`.

## Notes

- The swap button is `hidden sm:inline-flex`, so on phones there is no way to toggle — mobile now always gets the umpire-rows view. Happy to make the button visible on small screens in a follow-up if that matters.
- Cell rendering (and the `cell-<matchId>-<umpireId>` test ids) is shared between both orientations, so existing E2E selectors are unaffected.

## Test plan

- `npm run type-check` — passes
- `npx vitest run components/__tests__/assignment-grid.test.tsx` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ByVzYxUtFenFCgKXKvNbHv