### PR TITLE
chore: copy env and supabase link metadata into new worktrees

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,17 @@
+# Gitignored files copied into every new Orca worktree.
+# Literal paths only. Each must exist in the primary checkout and be gitignored,
+# otherwise it is silently skipped.
+
+# App + local Supabase credentials. Without this, `next dev` in a worktree fails
+# with "Your project's URL and Key are required to create a Supabase client!"
+.env.local
+
+# Supabase CLI project link. Without these, CLI commands that talk to the remote
+# project (`supabase db dump`, i.e. `npm run supabase:seed`) fail with
+# "Cannot find project ref. Have you run supabase link?".
+# Only the link metadata is copied — not the volatile runtime state in
+# supabase/.temp (container versions, start-secrets), which each worktree
+# should manage on its own.
+supabase/.temp/project-ref
+supabase/.temp/linked-project.json
+supabase/.temp/pooler-url


### PR DESCRIPTION
## Problem

Gitignored files do not follow a git worktree. A fresh worktree therefore starts without two things this repo needs, and both failures are non-obvious:

- **`.env.local` is missing** → `next dev` starts fine, but the first page render throws `Your project's URL and Key are required to create a Supabase client!`, because `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` are `undefined`.
- **The Supabase CLI project link is missing** (`supabase/.temp/`, gitignored via `supabase/.gitignore`) → `npm run supabase:seed` fails with `Cannot find project ref. Have you run supabase link?`.

Both had to be copied in from the primary checkout by hand before the app would run.

## Change

Adds a `.worktreeinclude` file, which Orca uses to copy the listed gitignored paths into each new worktree, so a worktree is usable before the first command runs.

Only the Supabase *link* metadata is listed (`project-ref`, `linked-project.json`, `pooler-url`) rather than all of `supabase/.temp` — that directory also holds volatile per-machine runtime state (container versions, `start-secrets`) which each worktree should manage on its own.

## Notes

- Every listed path is gitignored and present in the primary checkout, which is what the mechanism requires; tracked, missing, or non-ignored entries are silently skipped.
- Takes effect for worktrees created **after** this lands on `main`, since the file is read from the primary checkout.
- No application code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mg1u94DiH1GZgpk7UPxBdV