### PR TITLE
test: match poll headings by role in e2e poll spec

### DIFF
--- a/e2e/poll-response.spec.ts
+++ b/e2e/poll-response.spec.ts
@@ -6,7 +6,9 @@ test.describe("Poll response page", () => {
     const context = await browser.newContext();
     const page = await context.newPage();
     await page.goto("/poll/nonexistent-token-xyz");
-    await expect(page.getByText("Poll not found")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Poll not found" }),
+    ).toBeVisible();
     await context.close();
   });
 
@@ -68,7 +70,9 @@ test.describe("Poll response page", () => {
       umpirePage = await umpireContext.newPage();
 
       await umpirePage.goto(`/poll/${pollToken}`);
-      await expect(umpirePage.getByText(pollTitle)).toBeVisible();
+      await expect(
+        umpirePage.getByRole("heading", { name: pollTitle }),
+      ).toBeVisible();
 
       // Enter email (new umpire)
       await umpirePage.getByLabel("Your email").fill(umpireEmail);


### PR DESCRIPTION
## Problem

`e2e/poll-response.spec.ts:9` fails on `main`. It's a strict-mode violation, not a broken page: b50da73 (OG metadata) added `generateMetadata` to `app/poll/[token]/page.tsx`, so the page's `<title>` now carries the same text as its `<h1>` and `getByText("Poll not found")` resolves to two nodes.

## Changes

- `shows not found for invalid token` — `getByText("Poll not found")` → `getByRole("heading", { name: "Poll not found" })`.
- `umpire can fill out availability via poll link` — same latent collision: the found-poll metadata title is `"{pollTitle} — {clubName}"`, so `getByText(pollTitle)` matches the `<title>` and the `<h1>` both. Switched to `getByRole("heading", { name: pollTitle })`.

The remaining `getByText` assertions in the file target pages under `/protected`, which have no `generateMetadata` and still fall back to the static `"Fluitplanner"` title — unaffected.

## Verification

- `shows not found for invalid token` passes locally (2.7s).
- The four serial flow tests **skipped** — `test.skip(true, "No matches available to create a poll")` fires because the local DB has no matches. So the second fix is reasoned from source (all four poll-title renders in `components/poll-response/poll-response-page.tsx` are `<h1>`), not runtime-verified. CI should exercise it if its seed has matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRVwhaNVYGfA9sCiANMQgi