### PR TITLE
feat: use more screen width and declutter the assignment grid headers

### DIFF
--- a/__tests__/domain/team-names.test.ts
+++ b/__tests__/domain/team-names.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { stripClubPrefix } from "@/lib/domain/team-names";
+
+describe("stripClubPrefix", () => {
+  const club = "VVV HC";
+
+  it("strips a plain club prefix from a home team", () => {
+    expect(stripClubPrefix("VVV HC MO16-1", club)).toBe("MO16-1");
+  });
+
+  it("strips a combination club prefix", () => {
+    expect(stripClubPrefix("AMVJ/VVV HC JO14-1", club)).toBe("JO14-1");
+  });
+
+  it("leaves opposing clubs untouched", () => {
+    expect(stripClubPrefix("Amsterdam MO14-1", club)).toBe("Amsterdam MO14-1");
+    expect(stripClubPrefix("Xenios MO16-1", club)).toBe("Xenios MO16-1");
+    expect(stripClubPrefix("Zoetermeer JO18-1", club)).toBe(
+      "Zoetermeer JO18-1",
+    );
+  });
+
+  it("does not strip a club name that appears mid-name without a slash", () => {
+    expect(stripClubPrefix("Oud VVV HC MO16-1", club)).toBe(
+      "Oud VVV HC MO16-1",
+    );
+  });
+
+  it("matches case-insensitively", () => {
+    expect(stripClubPrefix("vvv hc MO16-1", club)).toBe("MO16-1");
+  });
+
+  it("returns the original when stripping would leave nothing", () => {
+    expect(stripClubPrefix("VVV HC", club)).toBe("VVV HC");
+    expect(stripClubPrefix("AMVJ/VVV HC ", club)).toBe("AMVJ/VVV HC ");
+  });
+
+  it("returns the original when no club name is known", () => {
+    expect(stripClubPrefix("VVV HC MO16-1", null)).toBe("VVV HC MO16-1");
+    expect(stripClubPrefix("VVV HC MO16-1", "")).toBe("VVV HC MO16-1");
+  });
+
+  it("treats regex metacharacters in the club name literally", () => {
+    expect(stripClubPrefix("H.C. Klein MO16-1", "H.C. Klein")).toBe("MO16-1");
+    expect(stripClubPrefix("HXCXKlein MO16-1", "H.C. Klein")).toBe(
+      "HXCXKlein MO16-1",
+    );
+  });
+
+  it("handles surrounding whitespace", () => {
+    expect(stripClubPrefix("  VVV HC MO16-1  ", club)).toBe("MO16-1");
+  });
+});

--- a/app/protected/layout.tsx
+++ b/app/protected/layout.tsx
@@ -30,7 +30,7 @@ export default async function ProtectedLayout({
     <main className="min-h-screen flex flex-col items-center">
       <div className="flex-1 w-full flex flex-col gap-20 items-center">
         <nav className="w-full flex justify-center border-b border-b-foreground/10 h-12 sm:h-16">
-          <div className="w-full max-w-5xl flex justify-between items-center p-3 px-4 sm:px-5 text-sm">
+          <div className="w-full max-w-7xl flex justify-between items-center p-3 px-4 sm:px-5 text-sm">
             <div className="flex gap-3 sm:gap-5 items-center font-semibold">
               <Link href="/protected">
                 <Image
@@ -82,7 +82,7 @@ export default async function ProtectedLayout({
             </div>
           </div>
         </nav>
-        <div className="flex-1 flex flex-col gap-20 w-full max-w-5xl p-5 overflow-hidden">
+        <div className="flex-1 flex flex-col gap-20 w-full max-w-7xl p-5 overflow-hidden">
           {children}
         </div>
 

--- a/app/protected/polls/[id]/page.tsx
+++ b/app/protected/polls/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { getPoll, getAvailableMatches } from "@/lib/actions/polls";
 import { getUmpiresForPoll } from "@/lib/actions/assignments";
 import { PollDetailClient } from "@/components/polls/poll-detail-client";
+import { getCurrentOrganizationName } from "@/lib/actions/tenant-actions";
 
 async function PollDetailLoader({
   params,
@@ -12,10 +13,11 @@ async function PollDetailLoader({
 }) {
   const { id } = await params;
 
-  const [poll, availableMatches, umpires] = await Promise.all([
+  const [poll, availableMatches, umpires, clubName] = await Promise.all([
     getPoll(id).catch(() => null),
     getAvailableMatches(id).catch(() => []),
     getUmpiresForPoll(id).catch(() => []),
+    getCurrentOrganizationName().catch(() => null),
   ]);
 
   if (!poll) {
@@ -27,6 +29,7 @@ async function PollDetailLoader({
       initialPoll={poll}
       availableMatches={availableMatches}
       umpires={umpires}
+      clubName={clubName}
     />
   );
 }

--- a/components/__tests__/assignment-grid.test.tsx
+++ b/components/__tests__/assignment-grid.test.tsx
@@ -347,4 +347,53 @@ describe("AssignmentGrid", () => {
       screen.getByRole("button", { name: "Not yet ready for this team level" }),
     ).toBeInTheDocument();
   });
+
+  it("keeps the note icon out of the flow in the transposed header", () => {
+    const withNote = [
+      { ...mockMatches[0], notes: "Don't assign Piet" },
+      mockMatches[1],
+    ];
+    render(<AssignmentGrid {...defaultProps} matches={withNote} transposed />);
+
+    // An in-flow icon made noted columns taller, knocking their fill bar and
+    // the cells beneath it out of line with every other column.
+    const note = screen.getByRole("button", { name: "Don't assign Piet" });
+    expect(note).toHaveClass("absolute");
+    expect(note.closest("th")).toHaveClass("relative");
+  });
+
+  it("strips the own club prefix from home teams in the transposed header", () => {
+    render(<AssignmentGrid {...defaultProps} transposed clubName="HC" />);
+
+    expect(screen.getByText("Amsterdam")).toBeInTheDocument();
+    expect(screen.queryByText("HC Amsterdam")).not.toBeInTheDocument();
+    // Opponents keep their full name.
+    expect(screen.getByText("HC Rotterdam")).toBeInTheDocument();
+  });
+
+  it("leaves team names untouched when no club name is known", () => {
+    render(<AssignmentGrid {...defaultProps} transposed />);
+
+    expect(screen.getByText("HC Amsterdam")).toBeInTheDocument();
+  });
+
+  it("shows the assignment count as a bar labelled with the exact count", () => {
+    const assignments: Assignment[] = [
+      {
+        id: "a1",
+        poll_id: "poll-1",
+        match_id: "m1",
+        umpire_id: "u1",
+        created_at: "2026-01-01T00:00:00Z",
+        organization_id: "test-org-id",
+      },
+    ];
+
+    render(
+      <AssignmentGrid {...defaultProps} assignments={assignments} transposed />,
+    );
+
+    expect(screen.getByRole("img", { name: "1/2" })).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "0/2" })).toBeInTheDocument();
+  });
 });

--- a/components/polls/assignment-grid.tsx
+++ b/components/polls/assignment-grid.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { createAssignment, deleteAssignment } from "@/lib/actions/assignments";
 import { mapMatchesToSlots } from "@/lib/domain/match-slot-mapping";
+import { stripClubPrefix } from "@/lib/domain/team-names";
 import {
   findConflicts,
   type AssignmentConflict,
@@ -29,6 +30,8 @@ type Props = {
   assignments: Assignment[];
   umpires: RosteredUmpire[];
   transposed?: boolean;
+  /** Own club name, stripped from home team labels so columns stay narrow. */
+  clubName?: string | null;
   onAssignmentsChange?: (assignments: Assignment[]) => void;
   /** Called after a match note is saved so the parent can refetch. */
   onNoteSaved?: () => void;
@@ -52,6 +55,7 @@ export function AssignmentGrid({
   assignments: initialAssignments,
   umpires,
   transposed = false,
+  clubName,
   onAssignmentsChange,
   onNoteSaved,
   onUmpireNoteSaved,
@@ -302,6 +306,30 @@ export function AssignmentGrid({
     );
   }
 
+  /**
+   * Assignment progress as a bar rather than a "0/2" pill: across a full poll
+   * the pills were the heaviest ink in the header, while empty/half/full reads
+   * at a glance. The exact count stays available as a tooltip.
+   */
+  function renderCountBar(matchId: string) {
+    const count = assignmentCounts.get(matchId) ?? 0;
+    const over = count > 2;
+    const label = `${count}/2`;
+    return (
+      <span
+        role="img"
+        aria-label={label}
+        title={label}
+        className="mt-1 block h-[3px] w-full overflow-hidden rounded-full bg-muted"
+      >
+        <span
+          className={`block h-full rounded-full ${over ? "bg-destructive" : "bg-primary"}`}
+          style={{ width: `${(Math.min(count, 2) / 2) * 100}%` }}
+        />
+      </span>
+    );
+  }
+
   function renderCountBadge(matchId: string) {
     const count = assignmentCounts.get(matchId) ?? 0;
     const variant =
@@ -436,7 +464,7 @@ export function AssignmentGrid({
                 return (
                   <th
                     key={match.id}
-                    className={`p-2 pt-0 text-center font-medium whitespace-nowrap min-w-24 ${showBorder ? "border-l-2 border-border" : ""}`}
+                    className={`relative p-2 pt-0 text-center font-medium whitespace-nowrap min-w-24 ${showBorder ? "border-l-2 border-border" : ""}`}
                   >
                     <div className="flex flex-col items-center gap-0.5">
                       {match.start_time && (
@@ -448,17 +476,24 @@ export function AssignmentGrid({
                           })}
                         </span>
                       )}
-                      <span className="text-[11px] leading-tight">
-                        {match.home_team} &ndash; {match.away_team}
+                      <span className="flex flex-col items-center text-[11px] leading-tight">
+                        <span>
+                          {stripClubPrefix(match.home_team, clubName)}
+                        </span>
+                        <span className="text-muted-foreground">
+                          {match.away_team}
+                        </span>
                       </span>
-                      <div className="flex items-center gap-1">
-                        {renderCountBadge(match.id)}
-                        <MatchNoteButton
-                          match={match}
-                          variant="indicator"
-                          onSaved={onNoteSaved}
-                        />
-                      </div>
+                      {/* Absolute so a note never adds a row: an in-flow icon made
+                          noted columns taller and knocked their fill bar, and the
+                          cells beneath it, out of line with every other column. */}
+                      <MatchNoteButton
+                        match={match}
+                        variant="indicator"
+                        onSaved={onNoteSaved}
+                        className="absolute right-0 top-0"
+                      />
+                      {renderCountBar(match.id)}
                     </div>
                   </th>
                 );

--- a/components/polls/poll-detail-client.tsx
+++ b/components/polls/poll-detail-client.tsx
@@ -40,6 +40,8 @@ type Props = {
   initialPoll: PollDetail;
   availableMatches: Match[];
   umpires: RosteredUmpire[];
+  /** Own club name, stripped from home team labels in the assignment grid. */
+  clubName?: string | null;
 };
 
 /**
@@ -57,6 +59,7 @@ export function PollDetailClient({
   initialPoll,
   availableMatches,
   umpires: initialUmpires,
+  clubName,
 }: Props) {
   const router = useRouter();
   const [poll, setPoll] = useState(initialPoll);
@@ -498,6 +501,7 @@ export function PollDetailClient({
             assignments={poll.assignments}
             umpires={umpires}
             transposed={transposed}
+            clubName={clubName}
             onAssignmentsChange={setLiveAssignments}
             onNoteSaved={refreshPoll}
             onUmpireNoteSaved={refreshUmpires}

--- a/lib/actions/tenant-actions.ts
+++ b/lib/actions/tenant-actions.ts
@@ -2,6 +2,7 @@
 
 import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
+import { getTenantId } from "@/lib/tenant";
 
 export type UserOrganization = {
   slug: string;
@@ -55,4 +56,22 @@ export async function switchOrganization(slug: string): Promise<void> {
     sameSite: "lax",
     secure: process.env.NODE_ENV === "production",
   });
+}
+
+/**
+ * Name of the organization the current request is scoped to, or null when
+ * there is no tenant context (root domain) or the lookup fails.
+ */
+export async function getCurrentOrganizationName(): Promise<string | null> {
+  const tenantId = await getTenantId();
+  if (!tenantId) return null;
+
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("organizations")
+    .select("name")
+    .eq("id", tenantId)
+    .maybeSingle();
+
+  return data?.name ?? null;
 }

--- a/lib/domain/team-names.ts
+++ b/lib/domain/team-names.ts
@@ -1,0 +1,30 @@
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Remove the poll's own club name from the front of a team name.
+ *
+ * Within a poll every home team belongs to the same club, so the club name
+ * distinguishes nothing and only widens the column. Both shapes the club uses
+ * are handled: the plain prefix ("VVV HC MO16-1") and the combination-team
+ * prefix ("AMVJ/VVV HC JO14-1"), which is why anything before the club name
+ * must end in a slash.
+ *
+ * Returns the original name when there is no club to strip, when the name does
+ * not start with it, or when stripping would leave nothing behind.
+ */
+export function stripClubPrefix(
+  team: string,
+  clubName: string | null | undefined,
+): string {
+  if (!clubName) return team;
+
+  const pattern = new RegExp(
+    `^\\s*(?:[^\\s/][^/]*/)?${escapeRegExp(clubName)}\\s+`,
+    "i",
+  );
+
+  const stripped = team.replace(pattern, "").trim();
+  return stripped.length > 0 ? stripped : team;
+}


### PR DESCRIPTION
## What

Two related changes to make the poll assignment grid usable on a laptop.

**Widen authenticated pages.** `app/protected/layout.tsx` capped every page at `max-w-5xl` (1024px), so content sat in a centred column with the rest of the viewport empty. Now `max-w-7xl` (1280px).

**Declutter the match column headers.** Columns were labelled `Home – Away` on one line, so the widest label set the column width and few matches fit on screen. The header is now stacked and stripped down:

- **Club prefix dropped from home teams.** Within a poll the club name is constant and distinguishes nothing. It is read from the tenant's organisation rather than hardcoded, via a new `getCurrentOrganizationName()`, and one rule handles both shapes the club uses — `VVV HC MO16-1` and `AMVJ/VVV HC JO14-1` both reduce to the team code. Opponents keep their full name.
- **The `0/2` pill became a fill bar.** Across a full poll the pills were the heaviest ink in the header, while empty / half / full reads at a glance. The exact count stays available as a `title` and an `aria-label`, and over-assignment still shows in the destructive colour.
- **The note indicator is positioned absolutely.** In flow it added a row to noted columns only, making them taller and knocking their fill bar — and the availability cells beneath it — out of line with every other column.

The non-transposed view keeps its single-line labels: there matches are rows, so the label does not drive column width and stacking would only make every row taller.

## Notes for review

- `stripClubPrefix` escapes regex metacharacters in the club name, requires anything before the club name to end in a slash (so `Oud VVV HC MO16-1` is left alone), matches case-insensitively, and returns the original when stripping would leave nothing or when no tenant context exists.
- The note button is positioned with classes appended to `NoteButton`'s existing string. Positioning classes do not collide with its hardcoded `h-6 w-6`, so the shared component is untouched and umpire notes elsewhere are unaffected.

## Testing

- `npm run type-check`, `npm run lint`, `npm run format:check` — all clean
- `npm test` — **522 passing** (was 509)
- 9 new unit tests for `stripClubPrefix`, written red-first
- 4 new component tests: note icon out of flow, prefix stripped, names untouched without a club name, fill bar exposing the exact count

Not yet verified in a browser — see the checklist below.

## Reviewer checklist

- [ ] Corner-pinned note icon does not crowd the time on the narrowest columns
- [ ] Fill bar is legible in dark mode
- [ ] `max-w-7xl` looks right on the other protected pages (matches, umpires, settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bgx1nVRh8zqPdzUH9Vbukx
